### PR TITLE
Remove package.json exports and change publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,6 @@ import { createLogger } from '@api3/commons/dist/logger';
 import { createLogger } from '@api3/commons/logger';
 ```
 
-#### Import relative to the "node_modules"
-
-This is the default CommonJS style and it applies if you have `moduleResolution` set to `Node` or `Node10` inside the
-`tsconfig.json`.
-
-#### The "exports" based import
-
-This is done via `package.json` field called [exports](https://nodejs.org/api/packages.html#package-entry-points). This
-field works for both CJS and ESM starting from Node version 12. In order for TS to support this, you need to make sure
-you use `moduleResolution` and `module` set to `Node16` inside `tsconfig.json`.
-
-```jsonc
-// tsconfig.json
-{
-  "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16"
-  }
-}
-```
-
 ## Release
 
 To release a new version follow these steps:

--- a/package.json
+++ b/package.json
@@ -11,11 +11,8 @@
     "dist",
     "src"
   ],
-  "exports": {
-    "./eslint": "./dist/eslint/index.js",
-    "./logger": "./dist/logger/index.js",
-    "./processing": "./dist/processing/index.js"
-  },
+  "main": "./dist/index.js",
+  "exports": "./dist/index.js",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "clean": "rm -rf coverage dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+// NOTE: Not exporting ESLint rules because they need to be imported in a special way inside .eslintrc.js config.
+export * from './logger';
+export * from './processing';


### PR DESCRIPTION
Simplify the publishing so that it works with older module resolutions. I verified these changes in Airnode and signed API.

## Context

I first wanted to do it "properly" using the "exports" field inside package.json. Node 16 is so old that it's even EoL now. The advantages are that we can specify what can be imported and on which path. There are two big use-cases specifically:
1. Hide internal modules (node will fail to require/import it unless there is a a corresponding export path defined)
2. Avoid importing from `dist` directory (the common workaround for this is to have a single `index.js` which export everything).
3. Better code splitting.

The disadvantages:
1. If you use a package with exports, you need to specify different module resolution when using TS

This was OK, because you didn't need to change the configuration and import the old way (using import from dist folder), but I realized this only works for TS and not Jest and webpack (in Airnode deployer). The proper way is apply the single entry point workaround. At this point we may just remove the exports and not complicate the setup further because the benefit is quite low.

## Breaking change

This will actually be a breaking change when published, but I don't want to publish v1 of the package. This is not very important since we are the only users of the package anyway.