### PR TITLE
Add support for logger context

### DIFF
--- a/src/logger/async-storage.ts
+++ b/src/logger/async-storage.ts
@@ -1,0 +1,10 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { LogContext } from '.';
+
+let asyncLocalStorage: AsyncLocalStorage<LogContext>;
+
+export const getAsyncLocalStorage = () => {
+  if (!asyncLocalStorage) asyncLocalStorage = new AsyncLocalStorage<LogContext>();
+  return asyncLocalStorage;
+};

--- a/src/logger/index.test.ts
+++ b/src/logger/index.test.ts
@@ -1,0 +1,111 @@
+import { noop } from 'lodash';
+
+import { type LogConfig, createBaseLogger, wrapper } from '.';
+
+const createTestLogger = (
+  logConfig: LogConfig = { enabled: true, minLevel: 'debug', format: 'json', colorize: false }
+) => {
+  const baseLogger = createBaseLogger(logConfig);
+  const logger = wrapper(baseLogger);
+  jest.spyOn(baseLogger, 'debug').mockImplementation(noop as any);
+  jest.spyOn(baseLogger, 'info').mockImplementation(noop as any);
+  jest.spyOn(baseLogger, 'warn').mockImplementation(noop as any);
+  jest.spyOn(baseLogger, 'error').mockImplementation(noop as any);
+  jest.spyOn(baseLogger, 'child').mockImplementation(noop as any);
+
+  return { baseLogger, logger };
+};
+
+describe('log context', () => {
+  it('works with sync functions', () => {
+    const { baseLogger, logger } = createTestLogger();
+
+    logger.runWithContext({ requestId: 'parent' }, () => {
+      logger.debug('parent start');
+      logger.runWithContext({ requestId: 'child' }, () => {
+        logger.debug('child');
+      });
+
+      logger.debug('parent end');
+    });
+
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { requestId: 'parent' });
+    expect(baseLogger.debug).toHaveBeenCalledWith('child', { requestId: 'child' });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { requestId: 'parent' });
+  });
+
+  it('works with async functions', async () => {
+    const { baseLogger, logger } = createTestLogger();
+
+    await logger.runWithContext({ requestId: 'parent' }, async () => {
+      logger.debug('parent start');
+      await logger.runWithContext({ requestId: 'child' }, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        logger.debug('child');
+      });
+
+      logger.debug('parent end');
+    });
+
+    expect(baseLogger.debug).toHaveBeenCalledTimes(3);
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { requestId: 'parent' });
+    expect(baseLogger.debug).toHaveBeenCalledWith('child', { requestId: 'child' });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { requestId: 'parent' });
+  });
+
+  it('works with deeply nested functions', async () => {
+    const { baseLogger, logger } = createTestLogger();
+
+    await logger.runWithContext({ parent: true }, async () => {
+      logger.debug('parent start');
+
+      await logger.runWithContext({ A: true }, async () => {
+        logger.debug('A start');
+
+        await logger.runWithContext({ B: true }, async () => {
+          setTimeout(() => logger.debug('C'), 25);
+          setTimeout(() => logger.debug('D'), 50);
+          setTimeout(() => logger.debug('E'), 75);
+
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          logger.debug('B end');
+        });
+
+        logger.debug('A end');
+      });
+
+      logger.debug('parent end');
+    });
+
+    expect(baseLogger.debug).toHaveBeenCalledTimes(8);
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { parent: true });
+    expect(baseLogger.debug).toHaveBeenCalledWith('A start', { parent: true, A: true });
+    expect(baseLogger.debug).toHaveBeenCalledWith('C', { parent: true, A: true, B: true });
+    expect(baseLogger.debug).toHaveBeenCalledWith('D', { parent: true, A: true, B: true });
+    expect(baseLogger.debug).toHaveBeenCalledWith('E', { parent: true, A: true, B: true });
+    expect(baseLogger.debug).toHaveBeenCalledWith('B end', { parent: true, A: true, B: true });
+    expect(baseLogger.debug).toHaveBeenCalledWith('A end', { parent: true, A: true });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { parent: true });
+  });
+
+  it('throws if the sync callback function throws', () => {
+    const { logger } = createTestLogger();
+
+    expect(() =>
+      logger.runWithContext({}, () => {
+        throw new Error('some-error');
+      })
+    ).toThrow('some-error');
+  });
+
+  it('returns rejected promise if the async callback function rejects', async () => {
+    const { logger } = createTestLogger();
+
+    await expect(async () =>
+      // eslint-disable-next-line @typescript-eslint/require-await
+      logger.runWithContext({}, async () => {
+        throw new Error('some-error');
+      })
+    ).rejects.toThrow('some-error');
+  });
+});

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,7 +1,7 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 import winston from 'winston';
 import { consoleFormat } from 'winston-console-format';
+
+import { getAsyncLocalStorage } from './async-storage';
 
 export const logFormatOptions = ['json', 'pretty'] as const;
 
@@ -70,13 +70,6 @@ export const createBaseLogger = (config: LogConfig) => {
     exitOnError: false,
     transports: [createConsoleTransport(config)],
   });
-};
-
-// TODO: Move to its own file so internalAsyncLocalStorage is not available and rename
-let internalAsyncLocalStorage: AsyncLocalStorage<LogContext>;
-const getAsyncLocalStorage = () => {
-  if (!internalAsyncLocalStorage) internalAsyncLocalStorage = new AsyncLocalStorage<LogContext>();
-  return internalAsyncLocalStorage;
 };
 
 export type LogContext = Record<string, any>;


### PR DESCRIPTION
Closes https://github.com/api3dao/commons/issues/21

## Rationale

The problem is outlined in the issue.

A while ago I implemented https://github.com/api3dao/airnode/pull/1353 which is done wrong. The metadata is common for the logger. This causes incorrect behaviour with parallel execution.

The idea of this API is to provide a way to attach log context to a function that persists while the function is running (or any async calls spawned from that function). In some languages, you can achieve this with decorators, but it's not possible in JS.

I've read some articles, how this is done in JS world. The most useful one being [this](https://blog.logrocket.com/context-aware-logging-node-js/) and [this](https://xebia.com/blog/contextual-logging-in-nodejs/), from which I tweaked the logger implementation. The API is:

```ts
// Runs the "callback" and every "logger.<function>" (even for nested calls) prints the "logContext".
logger.runWithContext(logContext, callback)
```

Take a look at the tests and source code to see how exactly it is used.

## Risks

The implementation is extremely small, all the heavy work is done by [NodeJS async context](https://nodejs.org/api/async_context.html#asynclocalstoragerunstore-callback-args) which **is stable**. The potential downside is performance, but the NodeJS team mentions they've done many non-trivial optimisations there.

In the [documentation](https://nodejs.org/api/async_context.html#troubleshooting-context-loss), I saw a warning of a potential context loss. The section is pretty vague, but losing the log context in a very rare cases is acceptable to me.