### PR TITLE
Document how to do a GH release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ To release a new version follow these steps:
    commit it.
 3. `pnpm publish --access public` - Publish the new version to NPM.
 4. `git push --follow-tags` - Push the tagged commit upstream.
+5. Create a new [release on GitHub](https://github.com/api3dao/commons/releases). Use the "Generate release notes"
+   feature to generate the release notes from the PR titles.
 
 ## Development notes
 


### PR DESCRIPTION
I realized we are not making GH releases after we publish a package which is a pity, since it's quite straightforward to do. I've generated the release and wrote instructions how to do that.

See: https://github.com/api3dao/commons/releases