### PR TITLE
Fix broken typings

### DIFF
--- a/src/logger/index.test.ts
+++ b/src/logger/index.test.ts
@@ -108,4 +108,20 @@ describe('log context', () => {
       })
     ).rejects.toThrow('some-error');
   });
+
+  it('can log using all variants of logger.error', () => {
+    const { baseLogger, logger } = createTestLogger();
+
+    logger.error('only message');
+    logger.error('message and context', { requestId: 'parent' });
+    logger.error('message and error', new Error('some-error'));
+    logger.error('message, error and context', new Error('some-error'), { requestId: 'parent' });
+
+    expect(baseLogger.error).toHaveBeenNthCalledWith(1, 'only message', undefined);
+    expect(baseLogger.error).toHaveBeenNthCalledWith(2, 'message and context', { requestId: 'parent' });
+    expect(baseLogger.error).toHaveBeenNthCalledWith(3, 'message and error', new Error('some-error'), undefined);
+    expect(baseLogger.error).toHaveBeenNthCalledWith(4, 'message, error and context', new Error('some-error'), {
+      requestId: 'parent',
+    });
+  });
 });


### PR DESCRIPTION
While implementing https://github.com/api3dao/airseeker-v2/issues/45 I realized that the typings change introduced in https://github.com/api3dao/commons/pull/22/files#diff-573cb92a5e5bcbab15c97c30712942467d928f15ab96f73347e798dd226e38f0R82 was incorrect.

This rollbacks that particular change and adds tests which ensure this will not happen again.