### PR TITLE
Implement processing v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tsc": "tsc --project ."
   },
   "dependencies": {
-    "@api3/ois": "^2.2.1",
+    "@api3/ois": "file:../ois",
     "@api3/promise-utils": "^0.4.0",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tsc": "tsc --project ."
   },
   "dependencies": {
-    "@api3/ois": "file:../ois",
+    "@api3/ois": "^2.3.0",
     "@api3/promise-utils": "^0.4.0",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@api3/ois':
-    specifier: file:../ois
-    version: file:../ois
+    specifier: ^2.3.0
+    version: 2.3.0
   '@api3/promise-utils':
     specifier: ^0.4.0
     version: 0.4.0
@@ -125,6 +125,13 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
+
+  /@api3/ois@2.3.0:
+    resolution: {integrity: sha512-B/F9sirQLBZNGClnpK/U585/gqYvjEHNKR5Xgc92LTvPe6F8w9RSW3JNZo4qAc+7Tzly9xr6kmoWQJsgnwD9iQ==}
+    dependencies:
+      lodash: 4.17.21
+      zod: 3.22.4
+    dev: false
 
   /@api3/promise-utils@0.4.0:
     resolution: {integrity: sha512-+8fcNjjQeQAuuSXFwu8PMZcYzjwjDiGYcMUfAQ0lpREb1zHonwWZ2N0B9h/g1cvWzg9YhElbeb/SyhCrNm+b/A==}
@@ -5052,12 +5059,4 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-    dev: false
-
-  file:../ois:
-    resolution: {directory: ../ois, type: directory}
-    name: '@api3/ois'
-    dependencies:
-      lodash: 4.17.21
-      zod: 3.22.4
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@api3/ois':
-    specifier: ^2.2.1
-    version: 2.2.1
+    specifier: file:../ois
+    version: file:../ois
   '@api3/promise-utils':
     specifier: ^0.4.0
     version: 0.4.0
@@ -125,13 +125,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
-
-  /@api3/ois@2.2.1:
-    resolution: {integrity: sha512-C4tSMBccDlD8NkZMVATQXOKctI46fSOlzpbZmZoFknsIdYfQvGNU49StGRJZ6fJJkwXEX1TlkRC7rY2yHEJjqw==}
-    dependencies:
-      lodash: 4.17.21
-      zod: 3.22.4
-    dev: false
 
   /@api3/promise-utils@0.4.0:
     resolution: {integrity: sha512-+8fcNjjQeQAuuSXFwu8PMZcYzjwjDiGYcMUfAQ0lpREb1zHonwWZ2N0B9h/g1cvWzg9YhElbeb/SyhCrNm+b/A==}
@@ -5059,4 +5052,12 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
+
+  file:../ois:
+    resolution: {directory: ../ois, type: directory}
+    name: '@api3/ois'
+    dependencies:
+      lodash: 4.17.21
+      zod: 3.22.4
     dev: false

--- a/src/processing/README.md
+++ b/src/processing/README.md
@@ -6,40 +6,115 @@ The pre/post processing is only supported for Node.js environments and uses inte
 
 ## Documentation
 
-The processing module exports two main functions:
+The processing module exports a multiple functions related to processing (both version 1 and 2). The most important
+functions are:
 
 <!-- NOTE: These are copied over from "processing.d.ts" from "dist" file. -->
 
 ```ts
 /**
- * Pre-processes API call parameters based on the provided endpoint's processing specifications.
+ * Pre-processes endpoint parameters based on the provided endpoint's processing specifications.
  *
- * @param endpoint The endpoint containing processing specifications.
- * @param apiCallParameters The parameters to be pre-processed.
+ * @param preProcessingSpecifications The v1 pre-processing specifications.
+ * @param endpointParameters The parameters to be pre-processed.
  * @param processingOptions Options to control the async processing behavior like retries and timeouts.
  *
  * @returns A promise that resolves to the pre-processed parameters.
  */
-export declare const preProcessApiCallParameters: (
-  endpoint: Endpoint,
-  apiCallParameters: ApiCallParameters,
+export declare const preProcessEndpointParametersV1: (
+  preProcessingSpecifications: ProcessingSpecifications | undefined,
+  endpointParameters: EndpointParameters,
   processingOptions?: GoAsyncOptions
-) => Promise<ApiCallParameters>;
+) => Promise<EndpointParameters>;
 
 /**
- * Post-processes the API call response based on the provided endpoint's processing specifications.
+ * Post-processes the response based on the provided endpoint's processing specifications. The response is usually the
+ * API call response, but this logic depends on how the processing is used by the target service. For example, Airnode
+ * allows skipping API calls in which case the response is the result of pre-processing.
  *
- * @param apiCallResponse The raw response obtained from the API call.
- * @param endpoint The endpoint containing processing specifications.
- * @param apiCallParameters The parameters used in the API call.
+ * @param response The response to be post-processed.
+ * @param postProcessingSpecifications The v1 post-processing specifications.
+ * @param endpointParameters The endpoint parameters.
  * @param processingOptions Options to control the async processing behavior like retries and timeouts.
  *
- * @returns A promise that resolves to the post-processed API call response.
+ * @returns A promise that resolves to the post-processed response.
  */
-export declare const postProcessApiCallResponse: (
-  apiCallResponse: unknown,
-  endpoint: Endpoint,
-  apiCallParameters: ApiCallParameters,
+export declare const postProcessResponseV1: (
+  response: unknown,
+  postProcessingSpecifications: ProcessingSpecifications | undefined,
+  endpointParameters: EndpointParameters,
   processingOptions?: GoAsyncOptions
 ) => Promise<unknown>;
+
+/**
+ * Pre-processes endpoint parameters based on the provided endpoint's processing specifications.
+ *
+ * @param preProcessingSpecificationV2 The v2 pre-processing specification.
+ * @param endpointParameters The parameters to be pre-processed.
+ * @param processingOptions Options to control the async processing behavior like retries and timeouts.
+ *
+ * @returns A promise that resolves to the pre-processed parameters.
+ */
+export declare const preProcessEndpointParametersV2: (
+  preProcessingSpecificationV2: ProcessingSpecificationV2 | undefined,
+  endpointParameters: EndpointParameters,
+  processingOptions?: GoAsyncOptions
+) => Promise<PreProcessingV2Response>;
+
+/**
+ * Post-processes the response based on the provided endpoint's processing specifications. The response is usually the
+ * API call response, but this logic depends on how the processing is used by the target service. For example, Airnode
+ * allows skipping API calls in which case the response is the result of pre-processing.
+ *
+ * @param response The response to be post-processed.
+ * @param postProcessingSpecificationV2 The v2 post-processing specification.
+ * @param endpointParameters The endpoint parameters.
+ * @param processingOptions Options to control the async processing behavior like retries and timeouts.
+ *
+ * @returns A promise that resolves to the post-processed response.
+ */
+export declare const postProcessResponseV2: (
+  response: unknown,
+  postProcessingSpecificationV2: ProcessingSpecificationV2 | undefined,
+  endpointParameters: EndpointParameters,
+  processingOptions?: GoAsyncOptions
+) => Promise<PostProcessingV2Response>;
+
+/**
+ * Pre-processes endpoint parameters based on the provided endpoint's processing specifications. Internally it
+ * determines what processing implementation should be used.
+ *
+ * @param endpoint The endpoint containing processing specifications.
+ * @param endpointParameters The parameters to be pre-processed.
+ * @param processingOptions Options to control the async processing behavior like retries and timeouts.
+ *
+ * @returns A promise that resolves to the pre-processed parameters.
+ */
+export declare const preProcessEndpointParameters: (
+  endpoint: Endpoint,
+  endpointParameters: EndpointParameters,
+  processingOptions?: GoAsyncOptions
+) => Promise<PreProcessingV2Response>;
+
+/**
+ * Post-processes the response based on the provided endpoint's processing specifications. The response is usually the
+ * API call response, but this logic depends on how the processing is used by the target service. For example, Airnode
+ * allows skipping API calls in which case the response is the result of pre-processing.
+ *
+ * This function determines what processing version should be used and provides a common interface. This is useful for
+ * services that want to use processing and don't care which processing version is used.
+ *
+ * @param response The response to be post-processed.
+ * @param endpoint The endpoint containing processing specifications.
+ * @param endpointParameters The endpoint parameters.
+ * @param processingOptions Options to control the async processing behavior like retries and timeouts.
+ *
+ * @returns A promise that resolves to the post-processed response.
+ */
+export declare const postProcessResponse: (
+  response: unknown,
+  endpoint: Endpoint,
+  endpointParameters: EndpointParameters,
+  processingOptions?: GoAsyncOptions
+) => Promise<PostProcessingV2Response>;
 ```

--- a/src/processing/processing.test.ts
+++ b/src/processing/processing.test.ts
@@ -1,10 +1,14 @@
 /* eslint-disable jest/prefer-strict-equal */ // Because the errors are thrown from the "vm" module (different context), they are not strictly equal.
+import { ZodError } from 'zod';
+
 import { createEndpoint } from '../../test/fixtures';
 
 import {
   addReservedParameters,
   postProcessApiCallResponse,
+  postProcessApiCallResponseV2,
   preProcessApiCallParameters,
+  preProcessApiCallParametersV2,
   removeReservedParameters,
 } from './processing';
 
@@ -175,8 +179,7 @@ describe(postProcessApiCallResponse.name, () => {
     const price = 1000;
     const result = await postProcessApiCallResponse({ price }, endpoint, parameters);
 
-    // reserved parameters (_times) should be inaccessible to post-processing for the
-    // http-gateway, hence multiplication by 2 instead of 1
+    // reserved parameters (_times) should be inaccessible to post-processing hence multiplication by 2 instead of 1
     expect(result).toEqual(price * myMultiplier * 2);
   });
 
@@ -268,5 +271,245 @@ describe(addReservedParameters.name, () => {
     const result = addReservedParameters(initialParameters, modifiedParameters);
 
     expect(result).toEqual(modifiedParameters);
+  });
+});
+
+describe(preProcessApiCallParametersV2.name, () => {
+  describe('migration from v1 processing', () => {
+    it('valid processing code', async () => {
+      const endpoint = createEndpoint({
+        preProcessingSpecificationV2: {
+          environment: 'Node async',
+          value: `
+              async (payload) => {
+                const { apiCallParameters } = payload;
+                return { apiCallParameters: {...apiCallParameters, from: 'ETH', newProp: 'airnode'} };
+              }
+            `,
+          timeoutMs: 5000,
+        },
+      });
+      const parameters = { _type: 'int256', _path: 'price' };
+
+      const result = await preProcessApiCallParametersV2(endpoint, parameters);
+
+      expect(result).toEqual({
+        apiCallParameters: {
+          _path: 'price',
+          _type: 'int256',
+          from: 'ETH',
+          newProp: 'airnode',
+        },
+      });
+    });
+
+    it('invalid processing code', async () => {
+      const endpoint = createEndpoint({
+        preProcessingSpecificationV2: {
+          environment: 'Node async',
+          value: 'something invalid; const output = {...input, from: `ETH`};',
+          timeoutMs: 5000,
+        },
+      });
+      const parameters = { _type: 'int256', _path: 'price', from: 'TBD' };
+
+      const throwingFunc = async () => preProcessApiCallParametersV2(endpoint, parameters);
+
+      await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
+    });
+
+    it('reserved parameters are inaccessible', async () => {
+      const parameters = { _type: 'int256', _path: 'price', to: 'USD' };
+      const endpoint = createEndpoint({
+        preProcessingSpecificationV2: {
+          environment: 'Node async',
+          // pretend the user is trying to 1) override _path and 2) set a new parameter based on
+          // the presence of the reserved parameter _type (which is inaccessible)
+          value: `
+            async ({apiCallParameters}) => {
+              return {apiCallParameters: {...apiCallParameters, from: "ETH", _path: "price.newpath", myVal: apiCallParameters._type ? "123" : "456", newTo: apiCallParameters.to } };
+            }
+            `,
+          timeoutMs: 5000,
+        },
+      });
+
+      const result = await preProcessApiCallParametersV2(endpoint, parameters);
+
+      expect(result).toEqual({
+        apiCallParameters: {
+          _path: 'price', // is not overridden
+          _type: 'int256',
+          from: 'ETH', // originates from the processing code
+          to: 'USD', // should be unchanged from the original parameters
+          myVal: '456', // is set to "456" because _type is not present in the environment
+          newTo: 'USD', // demonstrates access to apiCallParameters
+        },
+      });
+    });
+
+    it('uses native modules for processing', async () => {
+      const endpoint = createEndpoint({
+        preProcessingSpecificationV2: {
+          environment: 'Node async',
+          value: `
+          async ({apiCallParameters}) => {
+            const randomValue = crypto.randomBytes(4).toString('hex');
+            return {apiCallParameters: {...apiCallParameters, randomValue}};
+          }
+          `,
+          timeoutMs: 5000,
+        },
+      });
+      const parameters = { _type: 'int256', _path: 'price' };
+
+      const result = await preProcessApiCallParametersV2(endpoint, parameters);
+
+      // Check that the result contains the original parameters and a valid 8-character hex random value.
+      expect(result.apiCallParameters).toEqual({
+        _path: 'price',
+        _type: 'int256',
+        randomValue: expect.any(String),
+      });
+      expect(/^[\da-f]{8}$/i.test(result.apiCallParameters.randomValue)).toBe(true);
+    });
+
+    it('throws error due to processing timeout', async () => {
+      const endpoint = createEndpoint({
+        preProcessingSpecificationV2: {
+          environment: 'Node async',
+          value: `
+          async ({apiCallParameters}) => {
+            const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            await delay(5000);
+            return {apiCallParameters: {...apiCallParameters, from: 'ETH'}};
+          }`,
+          timeoutMs: 100, // This timeout is shorter than the delay in the processing code.
+        },
+      });
+      const parameters = { _type: 'int256', _path: 'price' };
+
+      const throwingFunc = async () => preProcessApiCallParametersV2(endpoint, parameters);
+
+      await expect(throwingFunc).rejects.toThrow('Full timeout exceeded');
+    });
+  });
+});
+
+describe(postProcessApiCallResponseV2.name, () => {
+  describe('migration from v1 processing', () => {
+    it('processes valid code', async () => {
+      const parameters = { _type: 'int256', _path: 'price' };
+      const endpoint = createEndpoint({
+        postProcessingSpecificationV2: {
+          environment: 'Node async',
+          value: `
+          async (payload) => {
+            const { apiCallResponse } = payload;
+            return { apiCallResponse: parseInt(apiCallResponse.price) * 4 };
+          }
+          `,
+          timeoutMs: 5000,
+        },
+      });
+
+      const result = await postProcessApiCallResponseV2({ price: 1000 }, endpoint, parameters);
+
+      expect(result).toEqual({ apiCallResponse: 4000 });
+    });
+
+    it('throws when the code is of incorrect shape', async () => {
+      const parameters = { _type: 'int256', _path: 'price' };
+      const endpoint = createEndpoint({
+        postProcessingSpecificationV2: {
+          environment: 'Node async',
+          value: `
+            async (payload) => {
+              const { apiCallResponse } = payload;
+              return  parseInt(apiCallResponse.price) * 4;
+            }
+            `,
+          timeoutMs: 5000,
+        },
+      });
+
+      await expect(async () => postProcessApiCallResponseV2({ price: 1000 }, endpoint, parameters)).rejects.toEqual(
+        new ZodError([
+          {
+            code: 'invalid_type',
+            expected: 'object',
+            received: 'number',
+            path: [],
+            message: 'Expected object, received number',
+          },
+        ])
+      );
+    });
+
+    it('demonstrates access to endpointParameters, but reserved parameters are inaccessible', async () => {
+      const myMultiplier = 10;
+      const parameters = { _type: 'int256', _path: 'price', myMultiplier };
+      const endpoint = createEndpoint({
+        postProcessingSpecificationV2: {
+          environment: 'Node async',
+          value: `
+            async (payload) => {
+              const {apiCallResponse, endpointParameters} = payload;
+              const reservedMultiplier = endpointParameters._times ? 1 : 2;
+              return {apiCallResponse: parseInt(apiCallResponse.price) * endpointParameters.myMultiplier * reservedMultiplier}
+            }
+          `,
+          timeoutMs: 5000,
+        },
+      });
+
+      const price = 1000;
+      const result = await postProcessApiCallResponseV2({ price }, endpoint, parameters);
+
+      // reserved parameters (_times) should be inaccessible to post-processing hence multiplication by 2 instead of 1
+      expect(result).toEqual({ apiCallResponse: price * myMultiplier * 2 });
+    });
+
+    it('throws on invalid code', async () => {
+      const parameters = { _type: 'int256', _path: 'price' };
+      const endpoint = createEndpoint({
+        postProcessingSpecificationV2: {
+          environment: 'Node async',
+          value: 'Something Unexpected;',
+          timeoutMs: 5000,
+        },
+      });
+
+      const throwingFunc = async () => postProcessApiCallResponseV2({ price: 1000 }, endpoint, parameters);
+
+      await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
+    });
+  });
+
+  it('can post-process timestamp', async () => {
+    const parameters = { _type: 'int256', _path: 'price' };
+    const endpoint = createEndpoint({
+      postProcessingSpecificationV2: {
+        environment: 'Node async',
+        value: `
+              async (payload) => {
+                const { apiCallResponse, timestamp } = payload;
+                return { apiCallResponse, timestamp: timestamp };
+              }
+            `,
+        timeoutMs: 5000,
+      },
+    });
+
+    const currentTimestamp = Math.floor(Date.now() / 1000);
+    const result1 = await postProcessApiCallResponseV2(
+      { price: 1000, timestamp: currentTimestamp },
+      endpoint,
+      parameters
+    );
+    expect(result1).toEqual({ apiCallResponse: { price: 1000, timestamp: currentTimestamp } });
+
+    const result2 = await postProcessApiCallResponseV2({ price: 1000 }, endpoint, parameters);
+    expect(result2).toEqual({ apiCallResponse: { price: 1000, timestamp: undefined } });
   });
 });

--- a/src/processing/processing.test.ts
+++ b/src/processing/processing.test.ts
@@ -281,7 +281,7 @@ describe(preProcessApiCallParametersV2.name, () => {
     it('valid processing code', async () => {
       const endpoint = createEndpoint({
         preProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           value: `
               async (payload) => {
                 const { apiCallParameters } = payload;
@@ -308,7 +308,7 @@ describe(preProcessApiCallParametersV2.name, () => {
     it('invalid processing code', async () => {
       const endpoint = createEndpoint({
         preProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           value: 'something invalid; const output = {...input, from: `ETH`};',
           timeoutMs: 5000,
         },
@@ -324,7 +324,7 @@ describe(preProcessApiCallParametersV2.name, () => {
       const parameters = { _type: 'int256', _path: 'price', to: 'USD' };
       const endpoint = createEndpoint({
         preProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           // pretend the user is trying to 1) override _path and 2) set a new parameter based on
           // the presence of the reserved parameter _type (which is inaccessible)
           value: `
@@ -353,7 +353,7 @@ describe(preProcessApiCallParametersV2.name, () => {
     it('uses native modules for processing', async () => {
       const endpoint = createEndpoint({
         preProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           value: `
           async ({apiCallParameters}) => {
             const randomValue = crypto.randomBytes(4).toString('hex');
@@ -379,7 +379,7 @@ describe(preProcessApiCallParametersV2.name, () => {
     it('throws error due to processing timeout', async () => {
       const endpoint = createEndpoint({
         preProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           value: `
           async ({apiCallParameters}) => {
             const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
@@ -404,7 +404,7 @@ describe(postProcessApiCallResponseV2.name, () => {
       const parameters = { _type: 'int256', _path: 'price' };
       const endpoint = createEndpoint({
         postProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           value: `
           async (payload) => {
             const { apiCallResponse } = payload;
@@ -424,7 +424,7 @@ describe(postProcessApiCallResponseV2.name, () => {
       const parameters = { _type: 'int256', _path: 'price' };
       const endpoint = createEndpoint({
         postProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           value: `
             async (payload) => {
               const { apiCallResponse } = payload;
@@ -453,7 +453,7 @@ describe(postProcessApiCallResponseV2.name, () => {
       const parameters = { _type: 'int256', _path: 'price', myMultiplier };
       const endpoint = createEndpoint({
         postProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           value: `
             async (payload) => {
               const {apiCallResponse, endpointParameters} = payload;
@@ -476,7 +476,7 @@ describe(postProcessApiCallResponseV2.name, () => {
       const parameters = { _type: 'int256', _path: 'price' };
       const endpoint = createEndpoint({
         postProcessingSpecificationV2: {
-          environment: 'Node async',
+          environment: 'Node',
           value: 'Something Unexpected;',
           timeoutMs: 5000,
         },
@@ -492,7 +492,7 @@ describe(postProcessApiCallResponseV2.name, () => {
     const parameters = { _type: 'int256', _path: 'price' };
     const endpoint = createEndpoint({
       postProcessingSpecificationV2: {
-        environment: 'Node async',
+        environment: 'Node',
         value: `
               async (payload) => {
                 const { apiCallResponse, timestamp } = payload;
@@ -520,7 +520,7 @@ describe(preProcessApiCallParameters.name, () => {
   it('returns v2 processing result', async () => {
     const endpoint = createEndpoint({
       preProcessingSpecificationV2: {
-        environment: 'Node async',
+        environment: 'Node',
         value: `
             async (payload) => {
               const { apiCallParameters } = payload;
@@ -579,7 +579,7 @@ describe(postProcessApiCallResponse.name, () => {
     const parameters = { _type: 'int256', _path: 'price' };
     const endpoint = createEndpoint({
       postProcessingSpecificationV2: {
-        environment: 'Node async',
+        environment: 'Node',
         value: `
         async (payload) => {
           const { apiCallResponse } = payload;

--- a/src/processing/processing.test.ts
+++ b/src/processing/processing.test.ts
@@ -5,17 +5,17 @@ import { createEndpoint } from '../../test/fixtures';
 
 import {
   addReservedParameters,
-  postProcessApiCallResponse,
-  postProcessApiCallResponseV1,
-  postProcessApiCallResponseV2,
-  preProcessApiCallParameters,
-  preProcessApiCallParametersV1,
-  preProcessApiCallParametersV2,
+  postProcessResponse,
+  postProcessResponseV1,
+  postProcessResponseV2,
+  preProcessEndpointParameters,
+  preProcessEndpointParametersV1,
+  preProcessEndpointParametersV2,
   removeReservedParameters,
 } from './processing';
 import type { ProcessingSpecificationV2, ProcessingSpecifications } from './schema';
 
-describe(preProcessApiCallParametersV1.name, () => {
+describe(preProcessEndpointParametersV1.name, () => {
   it('valid processing code', async () => {
     const preProcessingSpecifications = [
       {
@@ -31,7 +31,7 @@ describe(preProcessApiCallParametersV1.name, () => {
     ] as ProcessingSpecifications;
     const parameters = { _type: 'int256', _path: 'price' };
 
-    const result = await preProcessApiCallParametersV1(preProcessingSpecifications, parameters);
+    const result = await preProcessEndpointParametersV1(preProcessingSpecifications, parameters);
 
     expect(result).toEqual({
       _path: 'price',
@@ -56,7 +56,7 @@ describe(preProcessApiCallParametersV1.name, () => {
     ] as ProcessingSpecifications;
     const parameters = { _type: 'int256', _path: 'price', from: 'TBD' };
 
-    const throwingFunc = async () => preProcessApiCallParametersV1(preProcessingSpecifications, parameters);
+    const throwingFunc = async () => preProcessEndpointParametersV1(preProcessingSpecifications, parameters);
 
     await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
   });
@@ -74,7 +74,7 @@ describe(preProcessApiCallParametersV1.name, () => {
       },
     ] as ProcessingSpecifications;
 
-    const result = await preProcessApiCallParametersV1(preProcessingSpecifications, parameters);
+    const result = await preProcessEndpointParametersV1(preProcessingSpecifications, parameters);
 
     expect(result).toEqual({
       _path: 'price', // is not overridden
@@ -99,7 +99,7 @@ describe(preProcessApiCallParametersV1.name, () => {
     ] as ProcessingSpecifications;
     const parameters = { _type: 'int256', _path: 'price' };
 
-    const result = await preProcessApiCallParametersV1(preProcessingSpecifications, parameters);
+    const result = await preProcessEndpointParametersV1(preProcessingSpecifications, parameters);
 
     // Check that the result contains the original parameters and a valid 8-character hex random value.
     expect(result).toMatchObject({
@@ -124,13 +124,13 @@ describe(preProcessApiCallParametersV1.name, () => {
     ] as ProcessingSpecifications;
     const parameters = { _type: 'int256', _path: 'price' };
 
-    const throwingFunc = async () => preProcessApiCallParametersV1(preProcessingSpecifications, parameters);
+    const throwingFunc = async () => preProcessEndpointParametersV1(preProcessingSpecifications, parameters);
 
     await expect(throwingFunc).rejects.toThrow('Timeout exceeded');
   });
 });
 
-describe(postProcessApiCallResponseV1.name, () => {
+describe(postProcessResponseV1.name, () => {
   it('processes valid code', async () => {
     const parameters = { _type: 'int256', _path: 'price' };
     const postProcessingSpecifications = [
@@ -146,7 +146,7 @@ describe(postProcessApiCallResponseV1.name, () => {
       },
     ] as ProcessingSpecifications;
 
-    const result = await postProcessApiCallResponseV1({ price: 1000 }, postProcessingSpecifications, parameters);
+    const result = await postProcessResponseV1({ price: 1000 }, postProcessingSpecifications, parameters);
 
     expect(result).toBe(4000);
   });
@@ -166,7 +166,7 @@ describe(postProcessApiCallResponseV1.name, () => {
     ] as ProcessingSpecifications;
 
     const price = 1000;
-    const result = await postProcessApiCallResponseV1({ price }, postProcessingSpecifications, parameters);
+    const result = await postProcessResponseV1({ price }, postProcessingSpecifications, parameters);
 
     // reserved parameters (_times) should be inaccessible to post-processing hence multiplication by 2 instead of 1
     expect(result).toEqual(price * myMultiplier * 2);
@@ -190,8 +190,7 @@ describe(postProcessApiCallResponseV1.name, () => {
       },
     ] as ProcessingSpecifications;
 
-    const throwingFunc = async () =>
-      postProcessApiCallResponseV1({ price: 1000 }, postProcessingSpecifications, parameters);
+    const throwingFunc = async () => postProcessResponseV1({ price: 1000 }, postProcessingSpecifications, parameters);
 
     await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
   });
@@ -262,7 +261,7 @@ describe(addReservedParameters.name, () => {
   });
 });
 
-describe(preProcessApiCallParametersV2.name, () => {
+describe(preProcessEndpointParametersV2.name, () => {
   describe('migration from v1 processing', () => {
     it('valid processing code', async () => {
       const preProcessingSpecificationV2 = {
@@ -277,7 +276,7 @@ describe(preProcessApiCallParametersV2.name, () => {
       } as ProcessingSpecificationV2;
       const parameters = { _type: 'int256', _path: 'price' };
 
-      const result = await preProcessApiCallParametersV2(preProcessingSpecificationV2, parameters);
+      const result = await preProcessEndpointParametersV2(preProcessingSpecificationV2, parameters);
 
       expect(result).toEqual({
         endpointParameters: {
@@ -297,7 +296,7 @@ describe(preProcessApiCallParametersV2.name, () => {
       } as ProcessingSpecificationV2;
       const parameters = { _type: 'int256', _path: 'price', from: 'TBD' };
 
-      const throwingFunc = async () => preProcessApiCallParametersV2(preProcessingSpecificationV2, parameters);
+      const throwingFunc = async () => preProcessEndpointParametersV2(preProcessingSpecificationV2, parameters);
 
       await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
     });
@@ -316,7 +315,7 @@ describe(preProcessApiCallParametersV2.name, () => {
         timeoutMs: 5000,
       } as ProcessingSpecificationV2;
 
-      const result = await preProcessApiCallParametersV2(preProcessingSpecificationV2, parameters);
+      const result = await preProcessEndpointParametersV2(preProcessingSpecificationV2, parameters);
 
       expect(result).toEqual({
         endpointParameters: {
@@ -343,7 +342,7 @@ describe(preProcessApiCallParametersV2.name, () => {
       } as ProcessingSpecificationV2;
       const parameters = { _type: 'int256', _path: 'price' };
 
-      const result = await preProcessApiCallParametersV2(preProcessingSpecificationV2, parameters);
+      const result = await preProcessEndpointParametersV2(preProcessingSpecificationV2, parameters);
 
       // Check that the result contains the original parameters and a valid 8-character hex random value.
       expect(result.endpointParameters).toEqual({
@@ -367,14 +366,14 @@ describe(preProcessApiCallParametersV2.name, () => {
       } as ProcessingSpecificationV2;
       const parameters = { _type: 'int256', _path: 'price' };
 
-      const throwingFunc = async () => preProcessApiCallParametersV2(preProcessingSpecificationV2, parameters);
+      const throwingFunc = async () => preProcessEndpointParametersV2(preProcessingSpecificationV2, parameters);
 
       await expect(throwingFunc).rejects.toThrow('Full timeout exceeded');
     });
   });
 });
 
-describe(postProcessApiCallResponseV2.name, () => {
+describe(postProcessResponseV2.name, () => {
   describe('migration from v1 processing', () => {
     it('processes valid code', async () => {
       const parameters = { _type: 'int256', _path: 'price' };
@@ -389,7 +388,7 @@ describe(postProcessApiCallResponseV2.name, () => {
         timeoutMs: 5000,
       } as ProcessingSpecificationV2;
 
-      const result = await postProcessApiCallResponseV2({ price: 1000 }, postProcessingSpecificationV2, parameters);
+      const result = await postProcessResponseV2({ price: 1000 }, postProcessingSpecificationV2, parameters);
 
       expect(result).toEqual({ response: 4000 });
     });
@@ -408,7 +407,7 @@ describe(postProcessApiCallResponseV2.name, () => {
       } as ProcessingSpecificationV2;
 
       await expect(async () =>
-        postProcessApiCallResponseV2({ price: 1000 }, postProcessingSpecificationV2, parameters)
+        postProcessResponseV2({ price: 1000 }, postProcessingSpecificationV2, parameters)
       ).rejects.toEqual(
         new ZodError([
           {
@@ -438,7 +437,7 @@ describe(postProcessApiCallResponseV2.name, () => {
       } as ProcessingSpecificationV2;
 
       const price = 1000;
-      const result = await postProcessApiCallResponseV2({ price }, postProcessingSpecificationV2, parameters);
+      const result = await postProcessResponseV2({ price }, postProcessingSpecificationV2, parameters);
 
       // reserved parameters (_times) should be inaccessible to post-processing hence multiplication by 2 instead of 1
       expect(result).toEqual({ response: price * myMultiplier * 2 });
@@ -453,7 +452,7 @@ describe(postProcessApiCallResponseV2.name, () => {
       } as ProcessingSpecificationV2;
 
       const throwingFunc = async () =>
-        postProcessApiCallResponseV2({ price: 1000 }, postProcessingSpecificationV2, parameters);
+        postProcessResponseV2({ price: 1000 }, postProcessingSpecificationV2, parameters);
 
       await expect(throwingFunc).rejects.toEqual(new Error('SyntaxError: Unexpected identifier'));
     });
@@ -473,7 +472,7 @@ describe(postProcessApiCallResponseV2.name, () => {
     } as ProcessingSpecificationV2;
 
     const currentTimestamp = Math.floor(Date.now() / 1000);
-    const result1 = await postProcessApiCallResponseV2(
+    const result1 = await postProcessResponseV2(
       { price: 1000, timestamp: currentTimestamp },
       postProcessingSpecificationV2,
       parameters
@@ -483,12 +482,12 @@ describe(postProcessApiCallResponseV2.name, () => {
       timestamp: currentTimestamp,
     });
 
-    const result2 = await postProcessApiCallResponseV2({ price: 1000 }, postProcessingSpecificationV2, parameters);
+    const result2 = await postProcessResponseV2({ price: 1000 }, postProcessingSpecificationV2, parameters);
     expect(result2).toEqual({ response: { price: 1000 }, timestamp: undefined });
   });
 });
 
-describe(preProcessApiCallParameters.name, () => {
+describe(preProcessEndpointParameters.name, () => {
   it('returns v2 processing result', async () => {
     const endpoint = createEndpoint({
       preProcessingSpecificationV2: {
@@ -504,7 +503,7 @@ describe(preProcessApiCallParameters.name, () => {
     });
     const parameters = { _type: 'int256', _path: 'price' };
 
-    const result = await preProcessApiCallParameters(endpoint, parameters);
+    const result = await preProcessEndpointParameters(endpoint, parameters);
 
     expect(result).toEqual({
       endpointParameters: {
@@ -533,7 +532,7 @@ describe(preProcessApiCallParameters.name, () => {
     });
     const parameters = { _type: 'int256', _path: 'price' };
 
-    const result = await preProcessApiCallParameters(endpoint, parameters);
+    const result = await preProcessEndpointParameters(endpoint, parameters);
 
     expect(result).toEqual({
       endpointParameters: {
@@ -546,7 +545,7 @@ describe(preProcessApiCallParameters.name, () => {
   });
 });
 
-describe(postProcessApiCallResponse.name, () => {
+describe(postProcessResponse.name, () => {
   it('returns v2 processing result', async () => {
     const parameters = { _type: 'int256', _path: 'price' };
     const endpoint = createEndpoint({
@@ -562,7 +561,7 @@ describe(postProcessApiCallResponse.name, () => {
       },
     });
 
-    const result = await postProcessApiCallResponse({ price: 1000 }, endpoint, parameters);
+    const result = await postProcessResponse({ price: 1000 }, endpoint, parameters);
 
     expect(result).toEqual({ response: 4000 });
   });
@@ -584,7 +583,7 @@ describe(postProcessApiCallResponse.name, () => {
       ],
     });
 
-    const result = await postProcessApiCallResponse({ price: 1000 }, endpoint, parameters);
+    const result = await postProcessResponse({ price: 1000 }, endpoint, parameters);
 
     expect(result).toStrictEqual({ response: 4000 });
   });

--- a/src/processing/processing.test.ts
+++ b/src/processing/processing.test.ts
@@ -495,8 +495,8 @@ describe(postProcessApiCallResponseV2.name, () => {
         environment: 'Node',
         value: `
               async (payload) => {
-                const { apiCallResponse, timestamp } = payload;
-                return { apiCallResponse, timestamp: timestamp };
+                const { apiCallResponse } = payload;
+                return { apiCallResponse, timestamp: apiCallResponse.timestamp };
               }
             `,
         timeoutMs: 5000,
@@ -509,10 +509,13 @@ describe(postProcessApiCallResponseV2.name, () => {
       endpoint,
       parameters
     );
-    expect(result1).toEqual({ apiCallResponse: { price: 1000, timestamp: currentTimestamp } });
+    expect(result1).toEqual({
+      apiCallResponse: { price: 1000, timestamp: currentTimestamp },
+      timestamp: currentTimestamp,
+    });
 
     const result2 = await postProcessApiCallResponseV2({ price: 1000 }, endpoint, parameters);
-    expect(result2).toEqual({ apiCallResponse: { price: 1000, timestamp: undefined } });
+    expect(result2).toEqual({ apiCallResponse: { price: 1000 }, timestamp: undefined });
   });
 });
 

--- a/src/processing/processing.ts
+++ b/src/processing/processing.ts
@@ -9,7 +9,7 @@ import {
   type PreProcessingV2Response,
   type PostProcessingV2Response,
 } from './schema';
-import { unsafeEvaluate, unsafeEvaluateAsync, unsafeEvaluateAsyncV2 } from './unsafe-evaluate';
+import { unsafeEvaluate, unsafeEvaluateAsync, unsafeEvaluateV2 } from './unsafe-evaluate';
 
 export const DEFAULT_PROCESSING_TIMEOUT_MS = 10_000;
 
@@ -191,12 +191,8 @@ export const preProcessApiCallParametersV2 = async (
     const { environment, timeoutMs, value } = preProcessingSpecificationV2;
 
     switch (environment) {
-      case 'Node async': {
-        return unsafeEvaluateAsyncV2(
-          value,
-          { apiCallParameters: removeReservedParameters(apiCallParameters) },
-          timeoutMs
-        );
+      case 'Node': {
+        return unsafeEvaluateV2(value, { apiCallParameters: removeReservedParameters(apiCallParameters) }, timeoutMs);
       }
     }
   }, processingOptions);
@@ -237,8 +233,8 @@ export const postProcessApiCallResponseV2 = async (
     const endpointParameters = removeReservedParameters(apiCallParameters);
 
     switch (environment) {
-      case 'Node async': {
-        return unsafeEvaluateAsyncV2(value, { apiCallResponse, endpointParameters }, timeoutMs);
+      case 'Node': {
+        return unsafeEvaluateV2(value, { apiCallResponse, endpointParameters }, timeoutMs);
       }
     }
   }, processingOptions);

--- a/src/processing/schema.ts
+++ b/src/processing/schema.ts
@@ -1,17 +1,17 @@
 import { z } from 'zod';
 
-export const apiCallParametersSchema = z.record(z.any());
+export const endpointParametersSchema = z.record(z.any());
 
-export type ApiCallParameters = z.infer<typeof apiCallParametersSchema>;
+export type EndpointParameters = z.infer<typeof endpointParametersSchema>;
 
 export const preProcessingV2ResponseSchema = z.object({
-  apiCallParameters: apiCallParametersSchema,
+  endpointParameters: endpointParametersSchema,
 });
 
 export type PreProcessingV2Response = z.infer<typeof preProcessingV2ResponseSchema>;
 
 export const postProcessingV2ResponseSchema = z.object({
-  apiCallResponse: z.any(),
+  response: z.any(),
   timestamp: z.number().nonnegative().int().optional(),
 });
 

--- a/src/processing/schema.ts
+++ b/src/processing/schema.ts
@@ -1,10 +1,18 @@
-export const validateApiCallParameters = (apiCallParameters: unknown): ApiCallParameters => {
-  // eslint-disable-next-line lodash/prefer-lodash-typecheck
-  if (typeof apiCallParameters !== 'object' || apiCallParameters === null) {
-    throw new TypeError('Invalid API call parameters');
-  }
+import { z } from 'zod';
 
-  return apiCallParameters as ApiCallParameters;
-};
+export const apiCallParametersSchema = z.record(z.any());
 
-export type ApiCallParameters = Record<string, any>;
+export type ApiCallParameters = z.infer<typeof apiCallParametersSchema>;
+
+export const preProcessingV2ResponseSchema = z.object({
+  apiCallParameters: apiCallParametersSchema,
+});
+
+export type PreProcessingV2Response = z.infer<typeof preProcessingV2ResponseSchema>;
+
+export const postProcessingV2ResponseSchema = z.object({
+  apiCallResponse: z.any(),
+  timestamp: z.number().nonnegative().int().optional(),
+});
+
+export type PostProcessingV2Response = z.infer<typeof postProcessingV2ResponseSchema>;

--- a/src/processing/schema.ts
+++ b/src/processing/schema.ts
@@ -1,4 +1,9 @@
+import type { processingSpecificationSchemaV2, ProcessingSpecification } from '@api3/ois';
 import { z } from 'zod';
+
+export type ProcessingSpecificationV2 = z.infer<typeof processingSpecificationSchemaV2>;
+
+export type ProcessingSpecifications = ProcessingSpecification[];
 
 export const endpointParametersSchema = z.record(z.any());
 

--- a/src/processing/unsafe-evaluate.test.ts
+++ b/src/processing/unsafe-evaluate.test.ts
@@ -155,7 +155,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
       'setInterval',
       'clearTimeout',
       'clearInterval',
-      '__payload',
+      'payload',
     ]);
   });
 
@@ -163,7 +163,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
     const res = await unsafeEvaluateAsyncV2(
       `
       async (payload) => {
-        return [this.__payload, payload];
+        return [this.payload, payload];
       }
       `,
       123,

--- a/src/processing/unsafe-evaluate.test.ts
+++ b/src/processing/unsafe-evaluate.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jest/prefer-strict-equal */ // Because the errors are thrown from the "vm" module (different context), they are not strictly equal.
-import { unsafeEvaluate, unsafeEvaluateAsync } from './unsafe-evaluate';
+import { unsafeEvaluate, unsafeEvaluateAsync, unsafeEvaluateAsyncV2 } from './unsafe-evaluate';
 
 describe('unsafe evaluate - sync', () => {
   it('executes harmless code', () => {
@@ -99,5 +99,214 @@ describe('unsafe evaluate - async', () => {
     await expect(async () => unsafeEvaluateAsync("throw new Error('unexpected')", {}, 5000)).rejects.toEqual(
       new Error('unexpected')
     );
+  });
+});
+
+describe(unsafeEvaluateAsyncV2.name, () => {
+  it('has access to node modules and vm context', async () => {
+    const res = await unsafeEvaluateAsyncV2(
+      `
+      async () => {
+        return Object.keys(this);
+      }
+      `,
+      {},
+      100
+    );
+
+    expect(res).toEqual([
+      'assert',
+      'async_hooks',
+      'buffer',
+      'child_process',
+      'cluster',
+      'console',
+      'constants',
+      'crypto',
+      'dgram',
+      'dns',
+      'events',
+      'fs',
+      'http',
+      'http2',
+      'https',
+      'inspector',
+      'module',
+      'net',
+      'os',
+      'path',
+      'perf_hooks',
+      'process',
+      'readline',
+      'repl',
+      'stream',
+      'string_decoder',
+      'timers',
+      'tls',
+      'trace_events',
+      'tty',
+      'url',
+      'util',
+      'v8',
+      'vm',
+      'worker_threads',
+      'zlib',
+      'setTimeout',
+      'setInterval',
+      'clearTimeout',
+      'clearInterval',
+      '__payload',
+    ]);
+  });
+
+  it('can access vm context values as global variables', async () => {
+    const res = await unsafeEvaluateAsyncV2(
+      `
+      async (payload) => {
+        return [this.__payload, payload];
+      }
+      `,
+      123,
+      100
+    );
+
+    expect(res).toEqual([123, 123]);
+  });
+
+  it('works with sync function as well', async () => {
+    const res = await unsafeEvaluateAsyncV2(
+      `
+      (payload) => {
+        return payload + 500;
+      }
+      `,
+      123,
+      100
+    );
+
+    expect(res).toBe(623);
+  });
+
+  it('can use setTimeout and setInterval', async () => {
+    const res = await unsafeEvaluateAsyncV2(
+      `
+      async (payload) => {
+        const intervalId = setInterval(() => payload++, 50);
+        setTimeout(() => payload++, 50);
+        await new Promise((resolve) => {
+          clearInterval(intervalId);
+          setTimeout(resolve, 120);
+        });
+        return payload;
+      }
+      `,
+      0,
+      250
+    );
+
+    expect(res).toBe(3);
+  });
+
+  it('applies timeout', async () => {
+    await expect(async () =>
+      unsafeEvaluateAsyncV2(
+        `
+        async () => {
+          await new Promise((res) => setTimeout(res, 100));
+        }
+        `,
+        0,
+        50
+      )
+    ).rejects.toEqual(new Error('Full timeout exceeded'));
+  });
+
+  it('rejects on sync error', async () => {
+    await expect(async () =>
+      unsafeEvaluateAsyncV2(
+        `
+        () => {
+          return nonDefinedPayload + 500;
+        }
+        `,
+        {},
+        100
+      )
+    ).rejects.toEqual(new ReferenceError('nonDefinedPayload is not defined'));
+
+    await expect(async () =>
+      unsafeEvaluateAsyncV2(
+        `
+        () => {
+          throw new Error('some error');
+        }
+        `,
+        {},
+        100
+      )
+    ).rejects.toEqual(new Error('some error'));
+
+    await expect(async () =>
+      unsafeEvaluateAsyncV2(
+        `
+        () => {
+          throw 'non-error-value';
+        }
+        `,
+        {},
+        100
+      )
+    ).rejects.toBe('non-error-value');
+  });
+
+  it('allows using closures for modular code', async () => {
+    const res = await unsafeEvaluateAsyncV2(
+      `
+        async (payload) => {
+          const isDivisible = (n, k) => n % k === 0;
+
+          const isPrime = (n) => {
+            for (let i = 2; i < n; i++) {
+              if (isDivisible(n, i)) return false;
+            }
+            return true;
+          }
+
+          const ans = []
+          for (let i = 2; i < payload; i++) {
+            if (isPrime(i)) ans.push(i);
+          }
+          return ans;
+        }
+        `,
+      50,
+      1000
+    );
+
+    expect(res).toEqual([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]);
+  });
+
+  it('can use any async function syntax', async () => {
+    const anonymousArrowFnResult = await unsafeEvaluateAsyncV2(
+      `
+      async (payload) => {
+        return await Promise.resolve(payload + 500);
+      }
+      `,
+      123,
+      100
+    );
+    const regularFnResult = await unsafeEvaluateAsyncV2(
+      `
+      async function(payload) {
+        return await Promise.resolve(payload + 500);
+      }
+      `,
+      123,
+      100
+    );
+
+    expect(anonymousArrowFnResult).toBe(623);
+    expect(regularFnResult).toBe(623);
   });
 });

--- a/src/processing/unsafe-evaluate.test.ts
+++ b/src/processing/unsafe-evaluate.test.ts
@@ -305,8 +305,18 @@ describe(unsafeEvaluateV2.name, () => {
       123,
       100
     );
+    const regularFnReturningPromiseResult = await unsafeEvaluateV2(
+      `
+      function(payload) {
+        return Promise.resolve(payload + 500);
+      }
+      `,
+      123,
+      100
+    );
 
     expect(anonymousArrowFnResult).toBe(623);
     expect(regularFnResult).toBe(623);
+    expect(regularFnReturningPromiseResult).toBe(623);
   });
 });

--- a/src/processing/unsafe-evaluate.test.ts
+++ b/src/processing/unsafe-evaluate.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jest/prefer-strict-equal */ // Because the errors are thrown from the "vm" module (different context), they are not strictly equal.
-import { unsafeEvaluate, unsafeEvaluateAsync, unsafeEvaluateAsyncV2 } from './unsafe-evaluate';
+import { unsafeEvaluate, unsafeEvaluateAsync, unsafeEvaluateV2 } from './unsafe-evaluate';
 
 describe('unsafe evaluate - sync', () => {
   it('executes harmless code', () => {
@@ -102,9 +102,9 @@ describe('unsafe evaluate - async', () => {
   });
 });
 
-describe(unsafeEvaluateAsyncV2.name, () => {
+describe(unsafeEvaluateV2.name, () => {
   it('has access to node modules and vm context', async () => {
-    const res = await unsafeEvaluateAsyncV2(
+    const res = await unsafeEvaluateV2(
       `
       async () => {
         return Object.keys(this);
@@ -160,7 +160,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
   });
 
   it('can access vm context values as global variables', async () => {
-    const res = await unsafeEvaluateAsyncV2(
+    const res = await unsafeEvaluateV2(
       `
       async (payload) => {
         return [this.payload, payload];
@@ -174,7 +174,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
   });
 
   it('works with sync function as well', async () => {
-    const res = await unsafeEvaluateAsyncV2(
+    const res = await unsafeEvaluateV2(
       `
       (payload) => {
         return payload + 500;
@@ -188,7 +188,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
   });
 
   it('can use setTimeout and setInterval', async () => {
-    const res = await unsafeEvaluateAsyncV2(
+    const res = await unsafeEvaluateV2(
       `
       async (payload) => {
         const intervalId = setInterval(() => payload++, 50);
@@ -209,7 +209,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
 
   it('applies timeout', async () => {
     await expect(async () =>
-      unsafeEvaluateAsyncV2(
+      unsafeEvaluateV2(
         `
         async () => {
           await new Promise((res) => setTimeout(res, 100));
@@ -223,7 +223,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
 
   it('rejects on sync error', async () => {
     await expect(async () =>
-      unsafeEvaluateAsyncV2(
+      unsafeEvaluateV2(
         `
         () => {
           return nonDefinedPayload + 500;
@@ -235,7 +235,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
     ).rejects.toEqual(new ReferenceError('nonDefinedPayload is not defined'));
 
     await expect(async () =>
-      unsafeEvaluateAsyncV2(
+      unsafeEvaluateV2(
         `
         () => {
           throw new Error('some error');
@@ -247,7 +247,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
     ).rejects.toEqual(new Error('some error'));
 
     await expect(async () =>
-      unsafeEvaluateAsyncV2(
+      unsafeEvaluateV2(
         `
         () => {
           throw 'non-error-value';
@@ -260,7 +260,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
   });
 
   it('allows using closures for modular code', async () => {
-    const res = await unsafeEvaluateAsyncV2(
+    const res = await unsafeEvaluateV2(
       `
         async (payload) => {
           const isDivisible = (n, k) => n % k === 0;
@@ -287,7 +287,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
   });
 
   it('can use any async function syntax', async () => {
-    const anonymousArrowFnResult = await unsafeEvaluateAsyncV2(
+    const anonymousArrowFnResult = await unsafeEvaluateV2(
       `
       async (payload) => {
         return await Promise.resolve(payload + 500);
@@ -296,7 +296,7 @@ describe(unsafeEvaluateAsyncV2.name, () => {
       123,
       100
     );
-    const regularFnResult = await unsafeEvaluateAsyncV2(
+    const regularFnResult = await unsafeEvaluateV2(
       `
       async function(payload) {
         return await Promise.resolve(payload + 500);

--- a/src/processing/unsafe-evaluate.ts
+++ b/src/processing/unsafe-evaluate.ts
@@ -124,7 +124,7 @@ export const unsafeEvaluateAsyncV2 = async (code: string, payload: unknown, time
       vm.runInNewContext(
         `
           (async () => {
-            return await (${code})(__payload)
+            return await (${code})(payload)
           })();
         `,
         {
@@ -133,7 +133,7 @@ export const unsafeEvaluateAsyncV2 = async (code: string, payload: unknown, time
           setInterval: timers.customSetInterval,
           clearTimeout: timers.customClearTimeout,
           clearInterval: timers.customClearInterval,
-          __payload: payload,
+          payload,
         },
         { displayErrors: true, timeout }
       ),

--- a/src/processing/unsafe-evaluate.ts
+++ b/src/processing/unsafe-evaluate.ts
@@ -115,7 +115,7 @@ export const unsafeEvaluate = (code: string, globalVariables: Record<string, unk
   return vmContext.deferredOutput;
 };
 
-export const unsafeEvaluateAsyncV2 = async (code: string, payload: unknown, timeout: number) => {
+export const unsafeEvaluateV2 = async (code: string, payload: unknown, timeout: number) => {
   const timers = createTimers();
 
   const goEvaluate = await go<Promise<any>, GoWrappedError>(

--- a/src/processing/unsafe-evaluate.ts
+++ b/src/processing/unsafe-evaluate.ts
@@ -36,6 +36,8 @@ import vm from 'node:vm';
 import worker_threads from 'node:worker_threads';
 import zlib from 'node:zlib';
 
+import { type GoWrappedError, go } from '@api3/promise-utils';
+
 import { createTimers } from './vm-timers';
 
 const builtInNodeModules = {
@@ -111,6 +113,43 @@ export const unsafeEvaluate = (code: string, globalVariables: Record<string, unk
   });
 
   return vmContext.deferredOutput;
+};
+
+export const unsafeEvaluateAsyncV2 = async (code: string, payload: unknown, timeout: number) => {
+  const timers = createTimers();
+
+  const goEvaluate = await go<Promise<any>, GoWrappedError>(
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async () =>
+      vm.runInNewContext(
+        `
+          (async () => {
+            return await (${code})(__payload)
+          })();
+        `,
+        {
+          ...builtInNodeModules,
+          setTimeout: timers.customSetTimeout,
+          setInterval: timers.customSetInterval,
+          clearTimeout: timers.customClearTimeout,
+          clearInterval: timers.customClearInterval,
+          __payload: payload,
+        },
+        { displayErrors: true, timeout }
+      ),
+    // Make sure the timeout is applied. When the processing snippet uses setTimeout or setInterval, the timeout option
+    // from VM is broken. See: https://github.com/nodejs/node/issues/3020.
+    { totalTimeoutMs: timeout }
+  );
+
+  // We need to manually clear all timers and reject the processing manually.
+  timers.clearAll();
+
+  if (goEvaluate.success) {
+    return goEvaluate.data;
+  } else {
+    throw (goEvaluate.error.reason as Error) ?? goEvaluate.error;
+  }
 };
 
 /**


### PR DESCRIPTION
Relates to https://github.com/api3dao/commons/issues/27

## Rationale

The change starts with introducing new processing option in OIS, called `preProcessingSpecificationV2` and `postProcessingSpecificationV2` respectively. Note, that original issue only talks about post processing, but since we are changing the format is makes sense to also do pre processing.

The new processing code requires user to write a function which accepts the input as first argument and the output is a return value. This function can be both async or sync. See many examples in the tests. There are also tests which take the v1 snippets and convert them to v2.

The old implementation functions are suffixed with `V1` version and `postProcessApiCallResponse` and `preProcessApiCallParameters` abstract away which processing is used (under the hood they choose either v1 or v2 implementation) and they return a standard response. This is especially nice for end use, such as Airnode or Pusher. 