### PR TITLE
Create separate entry point for FE and BE

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,9 @@
 
 The commons library is meant to stop "reinventing the wheel". It holds the canonical implementations that can be
 imported in other packages. This way we ensure that all package use the same logic, simplify bug fixes and avoid code
-duplication.
+duplication. The package is cross platform and can be used in Node.js and browser.
 
-The commons library is a single repo and a collection of multiple modules:
-
-- [`eslint`](./src/eslint/README.md) - The configrations for ESLint.
-
-Read the documentation of each module for more information.
+The commons library is a collection of multiple modules, with each module having its own README that you can refer to.
 
 ## Related repositories
 
@@ -26,17 +22,23 @@ Read the documentation of each module for more information.
 pnpm add @api3/commons
 ```
 
-Read the documentation of each module how to use it in the project.
+Read the documentation and sources of each module how to use it in the project.
 
-### Import paths
+## Using the package in universal context
 
-There are two options how to import the commons modules, depending on the module resolution:
+Some modules may be used only in both browser and Node.js context and some are Node.js only. To support this
+requirement, we use different entrypoints for each context. Note, there is no support for browser-only modules.
 
-```ts
-// 1) Import relative to the "node_modules" directory.
-import { createLogger } from '@api3/commons/dist/logger';
-// 2) Cleaner imports based on the "exports" field in "package.json".
-import { createLogger } from '@api3/commons/logger';
+The bunder or Node.js picks up the right entrypoint automatically, but bear in mind that only a subset of modules is
+avaliable when using universal modules. If you use TypeScript, it may not pick up the correct types. You can set these
+manually, by adding the following to your `tsconfig.json`:
+
+```json
+"compilerOptions": {
+  "paths": {
+    "@api3/commons": ["./node_modules/@api3/commons/dist/universal-index.d.ts"]
+  }
+}
 ```
 
 ## Release
@@ -60,7 +62,7 @@ To release a new version follow these steps:
 
 1. Create a new directory in `src` with the name of the utility.
 2. Create `index.ts` file in the directory. This file will be the entry point for the utility.
-3. Re-export the new utility from the root `index.ts` file.
+3. Re-export the new utility from `universal-index.ts` or `node-index.ts` file.
 4. Create a `README.md` with documentation.
 
 #### Testing the package locally

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Read the documentation and sources of each module how to use it in the project.
 Some modules may be used only in both browser and Node.js context and some are Node.js only. To support this
 requirement, we use different entrypoints for each context. Note, there is no support for browser-only modules.
 
-The bunder or Node.js picks up the right entrypoint automatically, but bear in mind that only a subset of modules is
-avaliable when using universal modules. If you use TypeScript, it may not pick up the correct types. You can set these
+The bundler or Node.js picks up the right entrypoint automatically, but bear in mind that only a subset of modules is
+available when using universal modules. If you use TypeScript, it may not pick up the correct types. You can set these
 manually, by adding the following to your `tsconfig.json`:
 
 ```json

--- a/package.json
+++ b/package.json
@@ -11,8 +11,14 @@
     "dist",
     "src"
   ],
-  "main": "./dist/index.js",
-  "exports": "./dist/index.js",
+  "browser": "./dist/universal-index.js",
+  "main": "./dist/node-index.js",
+  "exports": {
+    ".": {
+      "browser": "./dist/universal-index.js",
+      "default": "./dist/node-index.js"
+    }
+  },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "clean": "rm -rf coverage dist",

--- a/src/node-index.ts
+++ b/src/node-index.ts
@@ -1,4 +1,4 @@
 // NOTE: Not exporting ESLint rules because they need to be imported in a special way inside .eslintrc.js config.
+export * from './universal-index';
 export * from './logger';
 export * from './processing';
-export * from './blockchain-utilities';

--- a/src/universal-index.ts
+++ b/src/universal-index.ts
@@ -1,0 +1,2 @@
+// NOTE: Only export modules which work in both Node.js and browser environments.
+export * from './blockchain-utilities';


### PR DESCRIPTION
Closes https://github.com/api3dao/commons/issues/45
Related to https://github.com/api3dao/commons/pull/18

## Rationale

The idea is to use separate entrypoints for Node.js and universal (runs both on browser and Node.js) code. This is accomplished via [browser](https://nodejs.org/api/packages.html#community-conditions-definitions) field and [exports](https://nodejs.org/api/packages.html#community-conditions-definitions) field. 

I intentionally name it as "universal" instead of "browser". If we end up adding some browser-only code to commons, it would make sense to separate this into multiple packages, because this can't be easily done without using `exports` only, which is not backwards compatible. Also, having a single package for these 3 cases is pretty complex.

I double checked the usage on a freshly created FE app and one of our private Node.js services.