### PR TITLE
Remove trace_events module from processing snippets

### DIFF
--- a/src/processing/unsafe-evaluate.test.ts
+++ b/src/processing/unsafe-evaluate.test.ts
@@ -143,7 +143,6 @@ describe(unsafeEvaluateV2.name, () => {
       'string_decoder',
       'timers',
       'tls',
-      'trace_events',
       'tty',
       'url',
       'util',

--- a/src/processing/unsafe-evaluate.ts
+++ b/src/processing/unsafe-evaluate.ts
@@ -27,7 +27,6 @@ import stream from 'node:stream';
 import string_decoder from 'node:string_decoder';
 import timers from 'node:timers';
 import tls from 'node:tls';
-import trace_events from 'node:trace_events';
 import tty from 'node:tty';
 import url from 'node:url';
 import util from 'node:util';
@@ -69,7 +68,6 @@ const builtInNodeModules = {
   string_decoder,
   timers,
   tls,
-  trace_events,
   tty,
   url,
   util,


### PR DESCRIPTION
Closes https://github.com/api3dao/commons/issues/42

## Rationale

This module is not available in all contexts and causes multiple issues (see the issue comments). We discussed on call what to do about this and we agreed:

1. Not to release a breaking change - No processing snippet should use this anyway
2. Not remove any other built-in module - This is to avoid risking breaking existing processing snippet use-cases.

I've removed the `trace_events` module and used the commons in Auctioneer, which fixed the [this](https://github.com/api3dao/commons/issues/42#issuecomment-1965948788) and [this](https://github.com/api3dao/commons/issues/42#issuecomment-1916339256) issue.