### PR TITLE
Refactor logger wrapper to improve context handling

### DIFF
--- a/src/logger/index.test.ts
+++ b/src/logger/index.test.ts
@@ -29,9 +29,9 @@ describe('log context', () => {
       logger.debug('parent end');
     });
 
-    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { requestId: 'parent' });
-    expect(baseLogger.debug).toHaveBeenCalledWith('child', { requestId: 'child' });
-    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { requestId: 'parent' });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { ctx: { requestId: 'parent' } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('child', { ctx: { requestId: 'child' } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { ctx: { requestId: 'parent' } });
   });
 
   it('works with async functions', async () => {
@@ -48,9 +48,9 @@ describe('log context', () => {
     });
 
     expect(baseLogger.debug).toHaveBeenCalledTimes(3);
-    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { requestId: 'parent' });
-    expect(baseLogger.debug).toHaveBeenCalledWith('child', { requestId: 'child' });
-    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { requestId: 'parent' });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { ctx: { requestId: 'parent' } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('child', { ctx: { requestId: 'child' } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { ctx: { requestId: 'parent' } });
   });
 
   it('works with deeply nested functions', async () => {
@@ -78,14 +78,14 @@ describe('log context', () => {
     });
 
     expect(baseLogger.debug).toHaveBeenCalledTimes(8);
-    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { parent: true });
-    expect(baseLogger.debug).toHaveBeenCalledWith('A start', { parent: true, A: true });
-    expect(baseLogger.debug).toHaveBeenCalledWith('C', { parent: true, A: true, B: true });
-    expect(baseLogger.debug).toHaveBeenCalledWith('D', { parent: true, A: true, B: true });
-    expect(baseLogger.debug).toHaveBeenCalledWith('E', { parent: true, A: true, B: true });
-    expect(baseLogger.debug).toHaveBeenCalledWith('B end', { parent: true, A: true, B: true });
-    expect(baseLogger.debug).toHaveBeenCalledWith('A end', { parent: true, A: true });
-    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { parent: true });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent start', { ctx: { parent: true } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('A start', { ctx: { parent: true, A: true } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('C', { ctx: { parent: true, A: true, B: true } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('D', { ctx: { parent: true, A: true, B: true } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('E', { ctx: { parent: true, A: true, B: true } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('B end', { ctx: { parent: true, A: true, B: true } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('A end', { ctx: { parent: true, A: true } });
+    expect(baseLogger.debug).toHaveBeenCalledWith('parent end', { ctx: { parent: true } });
   });
 
   it('throws if the sync callback function throws', () => {
@@ -118,10 +118,12 @@ describe('log context', () => {
     logger.error('message, error and context', new Error('some-error'), { requestId: 'parent' });
 
     expect(baseLogger.error).toHaveBeenNthCalledWith(1, 'only message', undefined);
-    expect(baseLogger.error).toHaveBeenNthCalledWith(2, 'message and context', { requestId: 'parent' });
+    expect(baseLogger.error).toHaveBeenNthCalledWith(2, 'message and context', { ctx: { requestId: 'parent' } });
     expect(baseLogger.error).toHaveBeenNthCalledWith(3, 'message and error', new Error('some-error'), undefined);
     expect(baseLogger.error).toHaveBeenNthCalledWith(4, 'message, error and context', new Error('some-error'), {
-      requestId: 'parent',
+      ctx: {
+        requestId: 'parent',
+      },
     });
   });
 });

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -112,13 +112,11 @@ export const wrapper = (logger: winston.Logger): Logger => {
     },
     // We need to handle both overloads of the `error` function
     error: (message, errorOrLocalContext: Error | LogContext, localContext?: LogContext) => {
-      const globalContext = getAsyncLocalStorage().getStore();
       // eslint-disable-next-line lodash/prefer-lodash-typecheck
       if (errorOrLocalContext instanceof Error) {
-        const fullContext = globalContext || localContext ? { ...globalContext, ...localContext } : undefined;
-        logger.error(message, errorOrLocalContext, fullContext);
+        logger.error(message, errorOrLocalContext, createFullContext(localContext));
       } else {
-        logger.error(message, createFullContext(localContext));
+        logger.error(message, createFullContext(errorOrLocalContext));
       }
     },
     child: (options) => wrapper(logger.child(options)),

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -61,7 +61,6 @@ export const createBaseLogger = (config: LogConfig) => {
     // This format is recommended by the "winston-console-format" package.
     format: winston.format.combine(
       winston.format.timestamp(),
-      winston.format.ms(),
       winston.format.errors({ stack: true }),
       winston.format.splat(),
       winston.format.json()
@@ -88,24 +87,28 @@ export interface Logger {
   child: (options: { name: string }) => Logger;
 }
 
+const createFullContext = (localContext: LogContext | undefined) => {
+  const globalContext = getAsyncLocalStorage().getStore();
+  if (!globalContext && !localContext) return;
+  const fullContext = { ...globalContext, ...localContext };
+
+  // If the context contains a `name` or `message` field, it will override the `name` and `message` fields of the log
+  // entry. To avoid this, we return the context as a separate field.
+  return { ctx: fullContext };
+};
+
 // Winston by default merges content of `context` among the rest of the fields for the JSON format.
 // That's causing an override of fields `name` and `message` if they are present.
 export const wrapper = (logger: winston.Logger): Logger => {
   return {
     debug: (message, localContext) => {
-      const globalContext = getAsyncLocalStorage().getStore();
-      const fullContext = globalContext || localContext ? { ...globalContext, ...localContext } : undefined;
-      logger.debug(message, fullContext);
+      logger.debug(message, createFullContext(localContext));
     },
     info: (message, localContext) => {
-      const globalContext = getAsyncLocalStorage().getStore();
-      const fullContext = globalContext || localContext ? { ...globalContext, ...localContext } : undefined;
-      logger.info(message, fullContext);
+      logger.info(message, createFullContext(localContext));
     },
     warn: (message, localContext) => {
-      const globalContext = getAsyncLocalStorage().getStore();
-      const fullContext = globalContext || localContext ? { ...globalContext, ...localContext } : undefined;
-      logger.warn(message, fullContext);
+      logger.warn(message, createFullContext(localContext));
     },
     // We need to handle both overloads of the `error` function
     error: (message, errorOrLocalContext: Error | LogContext, localContext?: LogContext) => {
@@ -115,9 +118,7 @@ export const wrapper = (logger: winston.Logger): Logger => {
         const fullContext = globalContext || localContext ? { ...globalContext, ...localContext } : undefined;
         logger.error(message, errorOrLocalContext, fullContext);
       } else {
-        const fullContext =
-          globalContext || errorOrLocalContext ? { ...globalContext, ...errorOrLocalContext } : undefined;
-        logger.error(message, fullContext);
+        logger.error(message, createFullContext(localContext));
       }
     },
     child: (options) => wrapper(logger.child(options)),


### PR DESCRIPTION
Closes https://github.com/api3dao/commons/issues/36

## Rationale

I came up with two ways:
1. Move all context fields in under a separate property (e.g. `ctx`)
2. Rename the conflicting context properties (`name` and `message`).

I think 2) is pretty confusing, so I went ahead with 1). I think it's also a bit nice that all of the context properties are grouped now instead of being flattened.

I also removed the `ms` field from the log, because that has very little purpose.

## Comparison

Having this code:
```ts
const logger = createLogger({ enabled: true, minLevel: 'debug', format: 'json', colorize: false });
logger.info('Original message', { message: 'Context message' });
```

Before this change, the following log was produced:
```json
{"level":"info","message":"Context message","ms":"+0ms","timestamp":"2024-02-27T21:13:38.976Z"}
```

After this change:
```json
{"ctx":{"message":"Context message"},"level":"info","message":"Original message","timestamp":"2024-02-27T21:12:34.090Z"}
```