### PR TITLE
Add deriveTemplateIdV1 function

### DIFF
--- a/src/blockchain-utilities/derivation.test.ts
+++ b/src/blockchain-utilities/derivation.test.ts
@@ -6,7 +6,8 @@ import {
   deriveBeaconSetId,
   deriveEndpointId,
   deriveSponsorWallet,
-  deriveTemplateId,
+  deriveTemplateIdV0,
+  deriveTemplateIdV1,
   deriveWalletPathFromSponsorAddress,
   fromBytes32String,
   PROTOCOL_IDS,
@@ -101,14 +102,23 @@ describe('deriveWalletPathFromSponsorAddress', () => {
       expect(endpointId).toBe('0x5a82d40e44ecd3ef0906e9e82c1a20f2f4ffe4f613ac70f999047496a9cd4635');
     });
 
-    it(`it derives a template ID`, () => {
-      const templateId = deriveTemplateId({
-        airnode: '0x4E95C31894a89CdC4288669A6F294836948c862b',
-        endpointId: '0x5a82d40e44ecd3ef0906e9e82c1a20f2f4ffe4f613ac70f999047496a9cd4635',
-        encodedParameters: '0x1234',
-      });
+    it(`it derives a template ID V0`, () => {
+      const templateId = deriveTemplateIdV0(
+        '0x4E95C31894a89CdC4288669A6F294836948c862b',
+        '0x5a82d40e44ecd3ef0906e9e82c1a20f2f4ffe4f613ac70f999047496a9cd4635',
+        '0x1234'
+      );
 
       expect(templateId).toBe('0x7655363f294273f84bcc7c47d79858cf46f21951deee92746d9f17a69ac0b0c0');
+    });
+
+    it('derives templateId for V1', () => {
+      const expectedTemplateIdV1 = deriveTemplateIdV1(
+        '0x6466726f6d63455448',
+        '0x2f3a3adf6daf5a3bb00ab83aa82262a6a84b59b0a89222386135330a1819ab48'
+      );
+
+      expect(expectedTemplateIdV1).toBe('0xe5d99287b5a870c3453bc0b42769c6f37cf4a3143890e9c34753181171fac842');
     });
 
     it('derives a beacon ID', () => {

--- a/src/blockchain-utilities/derivation.test.ts
+++ b/src/blockchain-utilities/derivation.test.ts
@@ -106,16 +106,16 @@ describe('deriveWalletPathFromSponsorAddress', () => {
       const templateId = deriveTemplateIdV0(
         '0x4E95C31894a89CdC4288669A6F294836948c862b',
         '0x5a82d40e44ecd3ef0906e9e82c1a20f2f4ffe4f613ac70f999047496a9cd4635',
-        '0x1234'
+        '0x6466726f6d63455448'
       );
 
-      expect(templateId).toBe('0x7655363f294273f84bcc7c47d79858cf46f21951deee92746d9f17a69ac0b0c0');
+      expect(templateId).toBe('0x25ea8b12135e4b8d49960ef9e0f967b7c0ccad136b955fbb7fbeb76da27d60b0');
     });
 
     it('derives templateId for V1', () => {
       const expectedTemplateIdV1 = deriveTemplateIdV1(
-        '0x6466726f6d63455448',
-        '0x2f3a3adf6daf5a3bb00ab83aa82262a6a84b59b0a89222386135330a1819ab48'
+        '0x2f3a3adf6daf5a3bb00ab83aa82262a6a84b59b0a89222386135330a1819ab48',
+        '0x6466726f6d63455448'
       );
 
       expect(expectedTemplateIdV1).toBe('0xe5d99287b5a870c3453bc0b42769c6f37cf4a3143890e9c34753181171fac842');

--- a/src/blockchain-utilities/derivation.ts
+++ b/src/blockchain-utilities/derivation.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 
-import { addressSchema } from './schema';
+import { type Address, addressSchema } from './schema';
 
 export const PROTOCOL_IDS = {
   RRP: '1',
@@ -11,23 +11,17 @@ export const PROTOCOL_IDS = {
 };
 
 /**
- * An interface that reflects the structure of a Template
- */
-export interface Template {
-  airnode: string;
-  encodedParameters: string;
-  endpointId: string;
-}
-
-/**
  * Derives a template ID from the input parameters
  *
  * @param airnode an Airnode address
  * @param encodedParameters encoded parameters, see the airnode/abi package's encode function
  * @param endpointId An endpointID (see deriveEndpointId)
  */
-export const deriveTemplateId = ({ airnode, encodedParameters, endpointId }: Template) =>
+export const deriveTemplateIdV0 = (airnode: Address, encodedParameters: string, endpointId: string) =>
   ethers.utils.solidityKeccak256(['address', 'bytes32', 'bytes'], [airnode, endpointId, encodedParameters]);
+
+export const deriveTemplateIdV1 = (encodedParameters: string, endpointId: string) =>
+  ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [endpointId, encodedParameters]);
 
 /**
  * Derives an endpoint ID

--- a/src/blockchain-utilities/derivation.ts
+++ b/src/blockchain-utilities/derivation.ts
@@ -17,10 +17,10 @@ export const PROTOCOL_IDS = {
  * @param encodedParameters encoded parameters, see the airnode/abi package's encode function
  * @param endpointId An endpointID (see deriveEndpointId)
  */
-export const deriveTemplateIdV0 = (airnode: Address, encodedParameters: string, endpointId: string) =>
+export const deriveTemplateIdV0 = (airnode: Address, endpointId: string, encodedParameters: string) =>
   ethers.utils.solidityKeccak256(['address', 'bytes32', 'bytes'], [airnode, endpointId, encodedParameters]);
 
-export const deriveTemplateIdV1 = (encodedParameters: string, endpointId: string) =>
+export const deriveTemplateIdV1 = (endpointId: string, encodedParameters: string) =>
   ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [endpointId, encodedParameters]);
 
 /**

--- a/src/blockchain-utilities/schema.ts
+++ b/src/blockchain-utilities/schema.ts
@@ -1,14 +1,9 @@
 import { z } from 'zod';
 
-/**
- * A Zod validation schema that represents an EVM-compatible address.
- */
 export const addressSchema = z.string().regex(/^0x[\dA-Fa-f]{40}$/, 'Must be a valid EVM address');
 
-/**
- * A Zod validation schema that represents an EVM-compatible hash, which includes beacon IDs and template IDs.
- */
+export type Address = z.infer<typeof addressSchema>;
+
 export const idSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM hash');
 
-export type Address = z.infer<typeof addressSchema>;
 export type Id = z.infer<typeof idSchema>;


### PR DESCRIPTION
Closes https://github.com/api3dao/commons/issues/52

## Rationale

I decided to rename `deriveTemplateId` to `deriveTemplateIdV0` because I expect there would be issues with it otherwise (people using the wrong one). This would normally be a breaking change, but I wouldn't want to release v1.0.0 because of this change (especially if this becomes a monorepo).