### PR TITLE
Extend validation schemas

### DIFF
--- a/src/blockchain-utilities/derivation.test.ts
+++ b/src/blockchain-utilities/derivation.test.ts
@@ -13,6 +13,7 @@ import {
   PROTOCOL_IDS,
   toBytes32String,
 } from './derivation';
+import type { Address } from './schema';
 
 describe('deriveWalletPathFromSponsorAddress', () => {
   it('converts address to derivation path', () => {
@@ -20,7 +21,7 @@ describe('deriveWalletPathFromSponsorAddress', () => {
     const res = deriveWalletPathFromSponsorAddress(sponsorAddress, PROTOCOL_IDS.AIRSEEKER);
     expect(res).toBe('5/973563544/2109481170/2137349576/871269377/610184194/17');
 
-    const randomAddress = ethers.utils.getAddress(ethers.utils.hexlify(ethers.utils.randomBytes(20)));
+    const randomAddress = ethers.utils.getAddress(ethers.utils.hexlify(ethers.utils.randomBytes(20))) as Address;
     const randomPath = deriveWalletPathFromSponsorAddress(randomAddress, PROTOCOL_IDS.AIRSEEKER);
     expect(res).not.toStrictEqual(randomPath);
   });
@@ -46,24 +47,24 @@ describe('deriveWalletPathFromSponsorAddress', () => {
   });
 
   it('throws if address is an empty string', () => {
-    const sponsorAddress = '';
+    const sponsorAddress = '' as Address;
     expect(() => deriveWalletPathFromSponsorAddress(sponsorAddress, PROTOCOL_IDS.AIRSEEKER)).toThrow(
       expect.objectContaining({ name: expect.stringContaining('Error') })
     );
   });
 
   it('throws if address is invalid', () => {
-    let sponsorAddress = '7dD0803Fd957723EdE10693A076698';
+    let sponsorAddress = '7dD0803Fd957723EdE10693A076698' as Address;
     expect(() => deriveWalletPathFromSponsorAddress(sponsorAddress, PROTOCOL_IDS.AIRSEEKER)).toThrow(
       expect.objectContaining({ name: expect.stringContaining('Error') })
     );
 
-    sponsorAddress = ethers.utils.hexlify(ethers.utils.randomBytes(4));
+    sponsorAddress = ethers.utils.hexlify(ethers.utils.randomBytes(4)) as Address;
     expect(() => deriveWalletPathFromSponsorAddress(sponsorAddress, PROTOCOL_IDS.AIRSEEKER)).toThrow(
       expect.objectContaining({ name: expect.stringContaining('Error') })
     );
 
-    sponsorAddress = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+    sponsorAddress = ethers.utils.hexlify(ethers.utils.randomBytes(32)) as Address;
     expect(() => deriveWalletPathFromSponsorAddress(sponsorAddress, PROTOCOL_IDS.AIRSEEKER)).toThrow(
       expect.objectContaining({ name: expect.stringContaining('Error') })
     );

--- a/src/blockchain-utilities/derivation.ts
+++ b/src/blockchain-utilities/derivation.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 
-import { type Address, addressSchema } from './schema';
+import { type Address, addressSchema, type Hex, type Mnemonic } from './schema';
 
 export const PROTOCOL_IDS = {
   RRP: '1',
@@ -17,10 +17,10 @@ export const PROTOCOL_IDS = {
  * @param encodedParameters encoded parameters, see the airnode/abi package's encode function
  * @param endpointId An endpointID (see deriveEndpointId)
  */
-export const deriveTemplateIdV0 = (airnode: Address, endpointId: string, encodedParameters: string) =>
+export const deriveTemplateIdV0 = (airnode: Address, endpointId: Hex, encodedParameters: Hex) =>
   ethers.utils.solidityKeccak256(['address', 'bytes32', 'bytes'], [airnode, endpointId, encodedParameters]);
 
-export const deriveTemplateIdV1 = (endpointId: string, encodedParameters: string) =>
+export const deriveTemplateIdV1 = (endpointId: Hex, encodedParameters: Hex) =>
   ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [endpointId, encodedParameters]);
 
 /**
@@ -37,7 +37,7 @@ export const deriveEndpointId = (oisTitle: string, endpointName: string) =>
  *
  * @param airnodeMnemonic the airnode's mnemonic
  */
-export const deriveAirnodeXpub = (airnodeMnemonic: string) =>
+export const deriveAirnodeXpub = (airnodeMnemonic: Mnemonic) =>
   ethers.utils.HDNode.fromMnemonic(airnodeMnemonic).derivePath("m/44'/60'/0'").neuter().extendedKey;
 
 /**
@@ -46,7 +46,7 @@ export const deriveAirnodeXpub = (airnodeMnemonic: string) =>
  * @param sponsorAddress an EVM-compatible address
  * @param protocolId an API application protocol ID
  */
-export function deriveWalletPathFromSponsorAddress(sponsorAddress: string, protocolId: string) {
+export function deriveWalletPathFromSponsorAddress(sponsorAddress: Address, protocolId: string) {
   addressSchema.parse(sponsorAddress);
 
   const sponsorAddressBN = ethers.BigNumber.from(sponsorAddress);
@@ -70,7 +70,7 @@ export const toBytes32String = (input: string) => ethers.utils.formatBytes32Stri
  *
  * @param input the input hex string
  */
-export const fromBytes32String = (input: string) => ethers.utils.parseBytes32String(input);
+export const fromBytes32String = (input: Hex) => ethers.utils.parseBytes32String(input);
 
 /**
  * Derives a sponsor wallet, given a mnemonic and dapiName.
@@ -78,9 +78,9 @@ export const fromBytes32String = (input: string) => ethers.utils.parseBytes32Str
  * @param sponsorWalletMnemonic the sponsor wallet mnemonic
  * @param dapiName the dapi name
  */
-export const deriveSponsorWallet = (sponsorWalletMnemonic: string, dapiName: string) => {
+export const deriveSponsorWallet = (sponsorWalletMnemonic: Mnemonic, dapiName: string) => {
   // Take first 20 bytes of dapiName as sponsor address together with the "0x" prefix.
-  const sponsorAddress = ethers.utils.getAddress(dapiName.slice(0, 42));
+  const sponsorAddress = ethers.utils.getAddress(dapiName.slice(0, 42)) as Address;
   const sponsorWallet = ethers.Wallet.fromMnemonic(
     sponsorWalletMnemonic,
     `m/44'/60'/0'/${
@@ -97,7 +97,7 @@ export const deriveSponsorWallet = (sponsorWalletMnemonic: string, dapiName: str
  * @param airnodeAddress the airnode address of the provider that supplies the data used to update this beacon
  * @param templateId the templateId of the template used to generate the data used to update this beacon
  */
-export const deriveBeaconId = (airnodeAddress: string, templateId: string) =>
+export const deriveBeaconId = (airnodeAddress: Address, templateId: Hex) =>
   ethers.utils.solidityKeccak256(['address', 'bytes32'], [airnodeAddress, templateId]);
 
 /**
@@ -106,5 +106,5 @@ export const deriveBeaconId = (airnodeAddress: string, templateId: string) =>
  *
  * @param beaconIds an ordered array of beacon ids
  */
-export const deriveBeaconSetId = (beaconIds: string[]) =>
+export const deriveBeaconSetId = (beaconIds: Hex[]) =>
   ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(['bytes32[]'], [beaconIds]));

--- a/src/blockchain-utilities/schema.test.ts
+++ b/src/blockchain-utilities/schema.test.ts
@@ -1,4 +1,4 @@
-import { addressSchema, idSchema } from './schema';
+import { addressSchema, keccak256HashSchema } from './schema';
 
 describe('schema', () => {
   it('validates a valid address', () => {
@@ -12,12 +12,14 @@ describe('schema', () => {
   });
 
   it('validates a valid ID', () => {
-    expect(() => idSchema.parse('0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')).not.toThrow();
+    expect(() =>
+      keccak256HashSchema.parse('0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')
+    ).not.toThrow();
   });
 
   it('throws for an invalid ID', () => {
-    expect(() => idSchema.parse('0xA3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')).toThrow(
-      expect.objectContaining({ name: 'ZodError' })
-    );
+    expect(() =>
+      keccak256HashSchema.parse('0xA3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')
+    ).toThrow(expect.objectContaining({ name: 'ZodError' }));
   });
 });

--- a/src/blockchain-utilities/schema.test.ts
+++ b/src/blockchain-utilities/schema.test.ts
@@ -1,8 +1,10 @@
 import { addressSchema, keccak256HashSchema } from './schema';
 
 describe('schema', () => {
-  it('validates a valid address', () => {
-    expect(() => addressSchema.parse('0x8A45eac0267dD0803Fd957723EdE10693A076698')).not.toThrow();
+  it('validates a valid address and returns its checksum', () => {
+    expect(addressSchema.parse('0x8a45eac0267dd0803fd957723ede10693a076698')).toBe(
+      '0x8A45eac0267dD0803Fd957723EdE10693A076698'
+    );
   });
 
   it('throws for an invalid address', () => {

--- a/src/blockchain-utilities/schema.test.ts
+++ b/src/blockchain-utilities/schema.test.ts
@@ -1,6 +1,6 @@
-import { addressSchema, keccak256HashSchema } from './schema';
+import { addressSchema, hexSchema, keccak256HashSchema, chainIdSchema, ethUnitsSchema, mnemonicSchema } from './schema';
 
-describe('schema', () => {
+describe('addressSchema', () => {
   it('validates a valid address and returns its checksum', () => {
     expect(addressSchema.parse('0x8a45eac0267dd0803fd957723ede10693a076698')).toBe(
       '0x8A45eac0267dD0803Fd957723EdE10693A076698'
@@ -12,7 +12,9 @@ describe('schema', () => {
       expect.objectContaining({ name: 'ZodError' })
     );
   });
+});
 
+describe('keccak256HashSchema', () => {
   it('validates a valid ID', () => {
     expect(() =>
       keccak256HashSchema.parse('0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')
@@ -22,6 +24,58 @@ describe('schema', () => {
   it('throws for an invalid ID', () => {
     expect(() =>
       keccak256HashSchema.parse('0xA3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')
+    ).toThrow(expect.objectContaining({ name: 'ZodError' }));
+  });
+});
+
+describe('hexSchema', () => {
+  it('validates a valid hex string', () => {
+    expect(() => hexSchema.parse('0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')).not.toThrow();
+  });
+
+  it('throws for an invalid hex string', () => {
+    expect(() => hexSchema.parse('3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')).toThrow(
+      expect.objectContaining({ name: 'ZodError' })
+    );
+  });
+});
+
+describe('chainIdSchema', () => {
+  it('validates a valid chain ID', () => {
+    expect(() => chainIdSchema.parse('1')).not.toThrow();
+  });
+
+  it('throws for an invalid chain ID', () => {
+    expect(() => chainIdSchema.parse('0')).toThrow(expect.objectContaining({ name: 'ZodError' }));
+  });
+});
+
+describe('ethUnitsSchema', () => {
+  it('validates a valid unit', () => {
+    expect(() => ethUnitsSchema.parse('wei')).not.toThrow();
+    expect(() => ethUnitsSchema.parse('kwei')).not.toThrow();
+    expect(() => ethUnitsSchema.parse('mwei')).not.toThrow();
+    expect(() => ethUnitsSchema.parse('gwei')).not.toThrow();
+    expect(() => ethUnitsSchema.parse('szabo')).not.toThrow();
+    expect(() => ethUnitsSchema.parse('finney')).not.toThrow();
+    expect(() => ethUnitsSchema.parse('ether')).not.toThrow();
+  });
+
+  it('throws for an invalid unit', () => {
+    expect(() => ethUnitsSchema.parse('wei2')).toThrow(expect.objectContaining({ name: 'ZodError' }));
+  });
+});
+
+describe('mnemonicSchema', () => {
+  it('validates a valid mnemonic', () => {
+    expect(() =>
+      mnemonicSchema.parse('destroy manual orange pole pioneer enemy detail lady cake bus shed visa')
+    ).not.toThrow();
+  });
+
+  it('throws for an invalid mnemonic', () => {
+    expect(() =>
+      mnemonicSchema.parse('destroy manual orange pole pioneer enemy detail lady cake bus shed WTF')
     ).toThrow(expect.objectContaining({ name: 'ZodError' }));
   });
 });

--- a/src/blockchain-utilities/schema.ts
+++ b/src/blockchain-utilities/schema.ts
@@ -4,6 +4,6 @@ export const addressSchema = z.string().regex(/^0x[\dA-Fa-f]{40}$/, 'Must be a v
 
 export type Address = z.infer<typeof addressSchema>;
 
-export const idSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM hash');
+export const keccak256HashSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM keccak256 hash');
 
-export type Id = z.infer<typeof idSchema>;
+export type Keccak256Hash = z.infer<typeof keccak256HashSchema>;

--- a/src/blockchain-utilities/schema.ts
+++ b/src/blockchain-utilities/schema.ts
@@ -25,7 +25,10 @@ export const keccak256HashSchema = z
 
 export type Keccak256Hash = z.infer<typeof keccak256HashSchema>;
 
-export const chainIdSchema = z.string().regex(/^\d+$/);
+export const chainIdSchema = z
+  .string()
+  .regex(/^\d+$/, 'Must be a valid chain ID')
+  .refine((chainId) => Number(chainId) > 0, 'Chain ID must be greater than 0');
 
 export type ChainId = z.infer<typeof chainIdSchema>;
 

--- a/src/blockchain-utilities/schema.ts
+++ b/src/blockchain-utilities/schema.ts
@@ -2,18 +2,47 @@ import { goSync } from '@api3/promise-utils';
 import { ethers } from 'ethers';
 import { z } from 'zod';
 
+export const hexSchema = z.string().regex(/^0x[\dA-Fa-f]+$/, 'Must be a valid hex string');
+
+export type Hex = `0x${string}`;
+
 export const addressSchema = z.string().transform((value, ctx) => {
   const goParseAddress = goSync(() => ethers.utils.getAddress(value));
   if (!goParseAddress.success) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Invalid EVM address' });
-    return;
+    return z.NEVER;
   }
 
-  return goParseAddress.data;
+  return goParseAddress.data as Hex;
 });
 
 export type Address = z.infer<typeof addressSchema>;
 
-export const keccak256HashSchema = z.string().regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM keccak256 hash');
+export const keccak256HashSchema = z
+  .string()
+  .regex(/^0x[\dA-Fa-f]{64}$/, 'Must be a valid EVM keccak256 hash')
+  .transform((val) => val as Hex);
 
 export type Keccak256Hash = z.infer<typeof keccak256HashSchema>;
+
+export const chainIdSchema = z.string().regex(/^\d+$/);
+
+export type ChainId = z.infer<typeof chainIdSchema>;
+
+export const ethUnitsSchema = z.union([
+  z.literal('wei'),
+  z.literal('kwei'),
+  z.literal('mwei'),
+  z.literal('gwei'),
+  z.literal('szabo'),
+  z.literal('finney'),
+  z.literal('ether'),
+]);
+
+export type EthUnits = z.infer<typeof ethUnitsSchema>;
+
+export const mnemonicSchema = z
+  .string()
+  .refine((mnemonic) => ethers.utils.isValidMnemonic(mnemonic), 'Invalid mnemonic');
+
+export type Mnemonic = z.infer<typeof mnemonicSchema>;

--- a/src/blockchain-utilities/schema.ts
+++ b/src/blockchain-utilities/schema.ts
@@ -1,6 +1,16 @@
+import { goSync } from '@api3/promise-utils';
+import { ethers } from 'ethers';
 import { z } from 'zod';
 
-export const addressSchema = z.string().regex(/^0x[\dA-Fa-f]{40}$/, 'Must be a valid EVM address');
+export const addressSchema = z.string().transform((value, ctx) => {
+  const goParseAddress = goSync(() => ethers.utils.getAddress(value));
+  if (!goParseAddress.success) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Invalid EVM address' });
+    return;
+  }
+
+  return goParseAddress.data;
+});
 
 export type Address = z.infer<typeof addressSchema>;
 

--- a/src/blockchain-utilities/schema.ts
+++ b/src/blockchain-utilities/schema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 export const hexSchema = z.string().regex(/^0x[\dA-Fa-f]+$/, 'Must be a valid hex string');
 
-export type Hex = `0x${string}`;
+export type Hex = `0x${string}`; // Not using z.infer<typeof hexSchema> because the inferred type is just `string`.
 
 export const addressSchema = z.string().transform((value, ctx) => {
   const goParseAddress = goSync(() => ethers.utils.getAddress(value));


### PR DESCRIPTION
Closes https://github.com/api3dao/commons/issues/47

## Rationale

I looked at Airnode, OevAuctioneer, Signed API and Airseeker v2 and extracted common utilities that might be useful across projects.

About parsing addresses. At first I wanted to lowercase them during validation, but it's actually more common for these to be checksummed. Because addresses are most often consumed via EVM library (viem, ethers...) which return checksummed addresses it makes sense to create the checksum version during validation as well.