### PR TITLE
Update engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": "^18.14.0 || ^20.10.0",
-    "pnpm": "^8.8.0"
+    "node": ">=18.14.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Having pnpm listed as engine causes a warning for all users that install the package and do not use pnpm (or use a wrong version). Related to this, commons works with any node version starting from `node@18` so we can just set `>=18.14.0`.