### PR TITLE
Fix package.json paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@api3/ois": "^2.3.2",
     "@api3/promise-utils": "^0.4.0",
-    "@octokit/rest": "^21.0.2",
+    "@octokit/rest": "^20.1.1",
     "@octokit/types": "^13.5.0",
     "axios": "^1.7.7",
     "dotenv": "^16.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@octokit/rest':
-        specifier: ^21.0.2
-        version: 21.0.2
+        specifier: ^20.1.1
+        version: 20.1.1
       '@octokit/types':
         specifier: ^13.5.0
         version: 13.5.0
@@ -544,20 +544,20 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@octokit/auth-token@5.1.1':
-    resolution: {integrity: sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==}
+  '@octokit/auth-token@4.0.0':
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
     engines: {node: '>= 18'}
 
-  '@octokit/core@6.1.2':
-    resolution: {integrity: sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==}
+  '@octokit/core@5.2.0':
+    resolution: {integrity: sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==}
     engines: {node: '>= 18'}
 
-  '@octokit/endpoint@10.1.1':
-    resolution: {integrity: sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==}
+  '@octokit/endpoint@9.0.5':
+    resolution: {integrity: sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==}
     engines: {node: '>= 18'}
 
-  '@octokit/graphql@8.1.1':
-    resolution: {integrity: sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==}
+  '@octokit/graphql@7.1.0':
+    resolution: {integrity: sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==}
     engines: {node: '>= 18'}
 
   '@octokit/openapi-types@22.2.0':
@@ -569,11 +569,11 @@ packages:
     peerDependencies:
       '@octokit/core': '5'
 
-  '@octokit/plugin-request-log@5.3.1':
-    resolution: {integrity: sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==}
+  '@octokit/plugin-request-log@4.0.1':
+    resolution: {integrity: sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==}
     engines: {node: '>= 18'}
     peerDependencies:
-      '@octokit/core': '>=6'
+      '@octokit/core': '5'
 
   '@octokit/plugin-rest-endpoint-methods@13.2.2':
     resolution: {integrity: sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==}
@@ -581,16 +581,16 @@ packages:
     peerDependencies:
       '@octokit/core': ^5
 
-  '@octokit/request-error@6.1.4':
-    resolution: {integrity: sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==}
+  '@octokit/request-error@5.1.0':
+    resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
     engines: {node: '>= 18'}
 
-  '@octokit/request@9.1.3':
-    resolution: {integrity: sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==}
+  '@octokit/request@8.4.0':
+    resolution: {integrity: sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==}
     engines: {node: '>= 18'}
 
-  '@octokit/rest@21.0.2':
-    resolution: {integrity: sha512-+CiLisCoyWmYicH25y1cDfCrv41kRSvTq6pPWtRroRJzhsCZWZyCqGyI8foJT5LmScADSwRAnr/xo+eewL04wQ==}
+  '@octokit/rest@20.1.1':
+    resolution: {integrity: sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==}
     engines: {node: '>= 18'}
 
   '@octokit/types@13.5.0':
@@ -938,8 +938,8 @@ packages:
   bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
 
-  before-after-hook@3.0.2:
-    resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
+  before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
   bn.js@4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
@@ -1177,6 +1177,9 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -2937,8 +2940,8 @@ packages:
   undici-types@6.19.6:
     resolution: {integrity: sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==}
 
-  universal-user-agent@7.0.2:
-    resolution: {integrity: sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==}
+  universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
   update-browserslist-db@1.0.13:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
@@ -3867,62 +3870,64 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  '@octokit/auth-token@5.1.1': {}
+  '@octokit/auth-token@4.0.0': {}
 
-  '@octokit/core@6.1.2':
+  '@octokit/core@5.2.0':
     dependencies:
-      '@octokit/auth-token': 5.1.1
-      '@octokit/graphql': 8.1.1
-      '@octokit/request': 9.1.3
-      '@octokit/request-error': 6.1.4
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.0
+      '@octokit/request': 8.4.0
+      '@octokit/request-error': 5.1.0
       '@octokit/types': 13.5.0
-      before-after-hook: 3.0.2
-      universal-user-agent: 7.0.2
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
 
-  '@octokit/endpoint@10.1.1':
+  '@octokit/endpoint@9.0.5':
     dependencies:
       '@octokit/types': 13.5.0
-      universal-user-agent: 7.0.2
+      universal-user-agent: 6.0.1
 
-  '@octokit/graphql@8.1.1':
+  '@octokit/graphql@7.1.0':
     dependencies:
-      '@octokit/request': 9.1.3
+      '@octokit/request': 8.4.0
       '@octokit/types': 13.5.0
-      universal-user-agent: 7.0.2
+      universal-user-agent: 6.0.1
 
   '@octokit/openapi-types@22.2.0': {}
 
-  '@octokit/plugin-paginate-rest@11.3.1(@octokit/core@6.1.2)':
+  '@octokit/plugin-paginate-rest@11.3.1(@octokit/core@5.2.0)':
     dependencies:
-      '@octokit/core': 6.1.2
+      '@octokit/core': 5.2.0
       '@octokit/types': 13.5.0
 
-  '@octokit/plugin-request-log@5.3.1(@octokit/core@6.1.2)':
+  '@octokit/plugin-request-log@4.0.1(@octokit/core@5.2.0)':
     dependencies:
-      '@octokit/core': 6.1.2
+      '@octokit/core': 5.2.0
 
-  '@octokit/plugin-rest-endpoint-methods@13.2.2(@octokit/core@6.1.2)':
+  '@octokit/plugin-rest-endpoint-methods@13.2.2(@octokit/core@5.2.0)':
     dependencies:
-      '@octokit/core': 6.1.2
+      '@octokit/core': 5.2.0
       '@octokit/types': 13.5.0
 
-  '@octokit/request-error@6.1.4':
+  '@octokit/request-error@5.1.0':
     dependencies:
       '@octokit/types': 13.5.0
+      deprecation: 2.3.1
+      once: 1.4.0
 
-  '@octokit/request@9.1.3':
+  '@octokit/request@8.4.0':
     dependencies:
-      '@octokit/endpoint': 10.1.1
-      '@octokit/request-error': 6.1.4
+      '@octokit/endpoint': 9.0.5
+      '@octokit/request-error': 5.1.0
       '@octokit/types': 13.5.0
-      universal-user-agent: 7.0.2
+      universal-user-agent: 6.0.1
 
-  '@octokit/rest@21.0.2':
+  '@octokit/rest@20.1.1':
     dependencies:
-      '@octokit/core': 6.1.2
-      '@octokit/plugin-paginate-rest': 11.3.1(@octokit/core@6.1.2)
-      '@octokit/plugin-request-log': 5.3.1(@octokit/core@6.1.2)
-      '@octokit/plugin-rest-endpoint-methods': 13.2.2(@octokit/core@6.1.2)
+      '@octokit/core': 5.2.0
+      '@octokit/plugin-paginate-rest': 11.3.1(@octokit/core@5.2.0)
+      '@octokit/plugin-request-log': 4.0.1(@octokit/core@5.2.0)
+      '@octokit/plugin-rest-endpoint-methods': 13.2.2(@octokit/core@5.2.0)
 
   '@octokit/types@13.5.0':
     dependencies:
@@ -4389,7 +4394,7 @@ snapshots:
 
   bech32@1.1.4: {}
 
-  before-after-hook@3.0.2: {}
+  before-after-hook@2.2.3: {}
 
   bn.js@4.12.0: {}
 
@@ -4655,6 +4660,8 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  deprecation@2.3.1: {}
 
   detect-newline@3.1.0: {}
 
@@ -6824,7 +6831,7 @@ snapshots:
 
   undici-types@6.19.6: {}
 
-  universal-user-agent@7.0.2: {}
+  universal-user-agent@6.0.1: {}
 
   update-browserslist-db@1.0.13(browserslist@4.22.1):
     dependencies:

--- a/scripts/tag-and-release.ts
+++ b/scripts/tag-and-release.ts
@@ -1,7 +1,9 @@
+import { join } from 'node:path';
+
 import { tagAndRelease } from '../src/release-scripts';
 
 const main = async () => {
-  await tagAndRelease('commons');
+  await tagAndRelease('commons', join(__dirname, '../package.json'));
 };
 
 main()

--- a/src/release-scripts/README.md
+++ b/src/release-scripts/README.md
@@ -12,26 +12,22 @@ defined in `package.json`.
 
 ### Usage
 
+It is recommended to 1) create a script that imports and uses the `tagAndRelease` function as demonstrated below, 2)
+define a script in `package.json`, and then 3) call that script as part of the CI process.
+
 ```ts
 // The following environment variable is expected. See the script itself for more details
 //
 //   GH_ACCESS_TOKEN - created through the Github UI with relevant permissions to the repo. See the tag-and-release source for more information
 
-import { tagAndRelease } from '@api3/commons';
-
-await tagAndRelease('my-repo-name'); // defaults to using the 'main' branch
-await tagAndRelease('my-repo-name', 'release-branch');
-```
-
-It is recommended to create a script that imports and uses the `tagAndRelease` function, setup a script in
-`package.json` and then call that script as part of the CI process.
-
-```ts
 // scripts/tag-and-release.ts
+import { join } from 'node:path';
+
 import { tagAndRelease } from '@api3/commons';
 
 const main = async () => {
-  await tagAndRelease('my-repo-name');
+  const packageJsonPath = join(__dirname, '../package.json'); // the script is one level deep in the repo
+  await tagAndRelease('my-repo-name', packageJsonPath, 'optional-branch-name-if-not-main');
 };
 
 main()

--- a/src/release-scripts/tag-and-release.ts
+++ b/src/release-scripts/tag-and-release.ts
@@ -16,7 +16,6 @@
 
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
 import { go } from '@api3/promise-utils';
 import { Octokit } from '@octokit/rest';
@@ -58,7 +57,7 @@ const createGithubRelease = async (repo: string, tagName: `v${string}`) => {
   return goRes.data;
 };
 
-export const tagAndRelease = async (repo: string, branch: string = 'main') => {
+export const tagAndRelease = async (repo: string, packageJsonPath: string, branch: string = 'main') => {
   console.info('Ensuring working directory is clean...');
   const gitStatus = execSyncWithErrorHandling('git status --porcelain');
   if (gitStatus !== '') throw new Error('Working directory is not clean');
@@ -73,7 +72,7 @@ export const tagAndRelease = async (repo: string, branch: string = 'main') => {
   const gitDiff = execSyncWithErrorHandling(`git diff origin/${branch}`);
   if (gitDiff !== '') throw new Error('Not up to date with the remote');
 
-  const packageJson = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf8')) as any;
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as any;
   const { version } = packageJson;
   console.info(`Version set to ${version}...`);
 


### PR DESCRIPTION
#130 introduced "BREAKING CHANGES package is now ESM" which causes import problems in calling packages when using the tag-and-release script (I tested this locally with another repo), so I reverted.

Closes #134 - @Siegrift I agree with [your comment ](https://github.com/api3dao/commons/issues/134#issuecomment-2344292838) that passing the path is easiest and most flexible. In my local testing this does read from the right `package.json`