### PR TITLE
fix: run npm config set before publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,8 @@ jobs:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Publish to npm
         if: ${{ steps.validate-tag.outputs.new-tag }}
-        run: pnpm publish --access public
+        run: |
+          npm config set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
+          pnpm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
OK! After a bit of testing all we need is to set the secret where npm wants it. Here is the key llines from my test repo:

https://github.com/dcroote/random-test-proj987/blob/96236eecc4059b46abbc26903eebb2ff059865c4/.github/workflows/build.yml#L36-L39

This is actually what the [changeset actions](https://github.com/changesets/action) does:

> By default the GitHub Action creates a .npmrc file with the following content:
`//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}`

And here is the published package, with provenance: https://www.npmjs.com/package/@dcroote/random-test-proj987

For the token, I used the Granular Access Token with Read and write scoped to only the specific package