### PR TITLE
fix: ignore octokit/rest in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:base"],
   "packageRules": [
     {
-      "matchPackageNames": ["node"],
+      "matchPackageNames": ["node", "@octokit/rest"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Because of https://github.com/api3dao/commons/pull/135#issue-2521129046