### PR TITLE
WIP: Create async task library

### DIFF
--- a/src/task/async-storage.ts
+++ b/src/task/async-storage.ts
@@ -1,0 +1,18 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface TaskOptions {
+  name?: string;
+  timeoutMs?: number;
+}
+
+export interface TaskContext {
+  startTimestampMs: number;
+  timeoutMs: number;
+}
+
+let asyncLocalStorage: AsyncLocalStorage<TaskContext>;
+
+export const getAsyncLocalStorage = () => {
+  if (!asyncLocalStorage) asyncLocalStorage = new AsyncLocalStorage<TaskContext>();
+  return asyncLocalStorage;
+};

--- a/src/task/index.test.ts
+++ b/src/task/index.test.ts
@@ -1,0 +1,40 @@
+import { sleep } from '../utils';
+
+import { runTask } from '.';
+
+describe(runTask.name, () => {
+  it('should run the task', async () => {
+    await runTask(
+      () => {
+        console.info('Hello');
+      },
+      { timeoutMs: 2000 }
+    );
+
+    expect(true).toBe(true);
+  });
+
+  it('works for nested tasks', async () => {
+    let fail = true;
+    await runTask(
+      async () => {
+        await runTask(
+          async () => {
+            await sleep(50);
+            // eslint-disable-next-line jest/no-conditional-in-test
+            if (fail) {
+              fail = false;
+              console.info('Child fail');
+              throw new Error('Failed');
+            }
+            console.info('Child success');
+          },
+          { name: 'child' }
+        );
+      },
+      { timeoutMs: 2000, name: 'parent' }
+    );
+
+    expect(true).toBe(true);
+  });
+});

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -1,0 +1,47 @@
+import { go } from '@api3/promise-utils';
+
+import { getAsyncLocalStorage, type TaskContext, type TaskOptions } from './async-storage';
+
+export const runTask = async (callback: () => void | Promise<void>, options?: TaskOptions) => {
+  const asyncStorage = getAsyncLocalStorage();
+  const inheritedContext = asyncStorage.getStore();
+
+  // Validate that the timeout is set for the root task.
+  if (!inheritedContext && !options?.timeoutMs) throw new Error('Root task must have a timeout');
+
+  while (true) {
+    // Determine the timeout for the current task.
+    const currentTaskStartTimestampMs = Date.now();
+    let timeoutMs: number | undefined = options?.timeoutMs;
+    if (inheritedContext) {
+      const timeLeft = Math.max(
+        0,
+        inheritedContext.timeoutMs - (currentTaskStartTimestampMs - inheritedContext.startTimestampMs)
+      );
+      timeoutMs = timeoutMs ? Math.min(timeoutMs, timeLeft) : timeLeft;
+    }
+
+    // Validate that there is still time left.
+    if (timeoutMs === undefined) throw new Error('Invariant broken: Timeout must be defined');
+    if (timeoutMs === 0) throw new Error('No time left for task');
+
+    // Create the task context.
+    const context: TaskContext = {
+      startTimestampMs: currentTaskStartTimestampMs,
+      timeoutMs,
+    };
+
+    // From https://nodejs.org/api/async_context.html#asynclocalstoragerunstore-callback-args
+    //
+    // If the callback function throws an error, the error is thrown by run() too. The stacktrace is not impacted by
+    // this call and the context is exited.
+    const callbackWithContext = () => asyncStorage.run(context, callback);
+
+    // Log the task attempt.
+    console.info(`Executing task`, options?.name ?? 'unknown', context);
+
+    // Run the callback with the context and timeout. In case the task fails, retry with whatever timeout is left.
+    const goResult = await go(callbackWithContext, { totalTimeoutMs: timeoutMs });
+    if (goResult.success) return goResult.data;
+  }
+};


### PR DESCRIPTION
## Rationale

I'll create a proper README later, but the high level idea is to support tasking library which can run a tasks (and subtasks) but propagate the task timeouts to child subtasks. All subtasks are retried indefinitely if there is some time left. This allows to apply a high level timeout for "features" that require many asynchronous operations to complete. 

For example, it's possible to start a task that runs for 5 seconds, including:
1. There is a GET request to be made, which should not take more than 1s.
2. A DB query which should take at most 500ms.
3. A call to get gas limit which should take 1s.
4. A blockchain tx that can take whatever time is needed.
  
 it would roughly be implemented like this:
 ```js
     runTask(
      async () => {
        await runTask(makeGetCall, { timeoutMs: 1000 });
        await runTask(makeDbQuery, { timeoutMs: 5000 });
        await runTask(getGasLimit, { timeoutMs: 1000 });
        await runTask(makeTx);
      },
      { timeoutMs: 5000 }
    );
 ```
 
 And a couple of points:
 1. The `makeTx` call would actually have a timeout applied - it would equal to whetever time is left from the 5s set by the root task.
 2. Any failure of the the tasks would be retried immediatelly and indefinitely, provided there is some time left.