### PR TITLE
Release v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api3/commons",
-  "version": "0.13.4",
+  "version": "1.0.0",
   "keywords": [],
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
The npm release [is available](https://www.npmjs.com/package/@api3/commons/v/1.0.0), but the `main` branch is protected and wouldn't accept a direct push from me (annoyingly the `git push --follow-tags --dry-run` command doesn't catch the remote rejected error) so I'm opening a PR (with the v1.0.0 tag) per step 4 of the dev release instructions:

https://github.com/api3dao/commons/blob/c03d9cefce9b1b888a9b7c9faef403c2c16d8d72/dev-README.md?plain=1#L16-L29

Note that the step instructions require a Rebase and merge