### PR TITLE
Use transform instead of refine to fix the Hex type

### DIFF
--- a/src/blockchain-utilities/schema.test.ts
+++ b/src/blockchain-utilities/schema.test.ts
@@ -31,12 +31,15 @@ describe('keccak256HashSchema', () => {
 describe('hexSchema', () => {
   it('validates a valid hex string', () => {
     expect(() => hexSchema.parse('0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')).not.toThrow();
+    expect(() => hexSchema.parse('0x3528e42b')).not.toThrow();
   });
 
   it('throws for an invalid hex string', () => {
     expect(() => hexSchema.parse('3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc')).toThrow(
       expect.objectContaining({ name: 'ZodError' })
     );
+    expect(() => hexSchema.parse('x3528e42b')).toThrow(expect.objectContaining({ name: 'ZodError' }));
+    expect(() => hexSchema.parse('')).toThrow(expect.objectContaining({ name: 'ZodError' }));
   });
 });
 

--- a/src/blockchain-utilities/schema.ts
+++ b/src/blockchain-utilities/schema.ts
@@ -2,9 +2,10 @@ import { goSync } from '@api3/promise-utils';
 import { ethers } from 'ethers';
 import { z } from 'zod';
 
-export const hexSchema = z.string().refine((val): val is `0x${string}` => /^0x[\dA-Fa-f]+$/.test(val), {
-  error: 'Invalid hex string format',
-});
+export const hexSchema = z
+  .string()
+  .regex(/^0x[\dA-Fa-f]+$/, 'Invalid hex string format')
+  .transform((val) => val as `0x${string}`);
 
 export type Hex = z.infer<typeof hexSchema>;
 


### PR DESCRIPTION
The `Hex` type changed to just a `string` after the Zod 4 migration because Zod 4 ignores type predicates in `.refine()`: https://zod.dev/v4/changelog?id=ignores-type-predicates 

This fix gets the `Hex` type back to `0x${string}`