### PR TITLE
Release 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api3/commons",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "keywords": [],
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
After this is released, the `promise-utils` repo can be deprecated.